### PR TITLE
Rename kubeconfig context name 💅

### DIFF
--- a/src/kubeconfig.rs
+++ b/src/kubeconfig.rs
@@ -98,7 +98,7 @@ impl KubeConfig {
             embed_certs,
         ])?;
 
-        let context = "default";
+        let context = "kubernix";
         kubectl.config(&[
             "set-context",
             context,


### PR DESCRIPTION
It's kinda hard to know what are we targeted when using the
configuration (if using `KUBECONFIG` in the prompt or somewhere
else). This change the context name for the generated kubeconfig to
`kubernix` instead of default.

@saschagrunert I am willing to add a flag for this, I just don't know
`rust` that much (or *at all* if I'm being honest) :stuck_out_tongue_closed_eyes: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>