### PR TITLE
Build(deps): Update nixpkgs to Kubernetes v1.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ The following technology stack is currently being used:
 | conntrack-tools | v1.4.8   |
 | cri-o-wrapper   | v1.35.0  |
 | cri-tools       | v1.35.0  |
-| crun            | v1.27    |
-| etcd            | v3.6.9   |
+| crun            | v1.27.1  |
+| etcd            | v3.6.10  |
 | iproute2        | v6.19.0  |
-| iptables        | v1.8.12  |
+| iptables        | v1.8.13  |
 | kmod            | v31      |
-| kubectl         | v1.35.3  |
-| kubernetes      | v1.35.3  |
+| kubectl         | v1.36.0  |
+| kubernetes      | v1.36.0  |
 | nss-cacert      | v3.121   |
-| podman          | v5.8.1   |
+| podman          | v5.8.2   |
 | socat           | v1.8.1.1 |
 | sysctl          | v4.0.6   |
-| util-linux      | v2.41.3  |
+| util-linux      | v2.42    |
 
 Some other tools are not explicitly mentioned here, because they are no
 first-level dependencies.

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates nixpkgs from 2026-03-28 to 2026-05-05. Notable version bumps:
- kubernetes/kubectl: v1.35.3 -> v1.36.0
- etcd: v3.6.9 -> v3.6.10
- podman: v5.8.1 -> v5.8.2
- crun: v1.27 -> v1.27.1
- iptables: v1.8.12 -> v1.8.13
- util-linux: v2.41.3 -> v2.42