### PR TITLE
Improve docs, add rustdoc examples, remove unsafe code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "temp-env",
  "tempfile",
  "toml",
 ]
@@ -377,6 +378,15 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -416,6 +426,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -495,6 +528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +554,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -592,6 +640,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +660,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,5 @@ signal-hook = "0.4.4"
 toml = "1.1.2"
 
 [dev-dependencies]
+temp-env = "0.3.6"
 tempfile = "3.27.0"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ The following technology stack is currently being used:
 Some other tools are not explicitly mentioned here, because they are no
 first-level dependencies.
 
+### Boot Phases
+
+Components start in four sequential phases. Within each phase, components
+start in parallel. If any component in a phase fails, subsequent phases
+are skipped.
+
+```mermaid
+graph TD
+    A["Phase 1: Infrastructure"] --> B["Phase 2: ControlPlane"]
+    B --> C["Phase 3: Controller"]
+    C --> D["Phase 4: NodeAgent"]
+
+    A --- etcd
+    B --- apiserver
+    C --- scheduler & controller-manager & cri-o["cri-o (x N)"] & proxy
+    D --- kubelet["kubelet (x N)"]
+```
+
 ### Single Dependency
 
 #### With Nix
@@ -207,7 +225,7 @@ components. For example, etcd gets started via:
 
 ```json
 {
-  "command": "/nix/store/…-etcd-3.6.9-bin/bin/etcd",
+  "command": "/nix/store/…-etcd-3.6.11-bin/bin/etcd",
   "args": [
     "--advertise-client-urls=https://127.0.0.1:2379",
     "--client-cert-auth",

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// Output format for log messages
+/// Output format for log messages.
+///
+/// ```
+/// use kubernix::LogFormat;
+///
+/// assert_eq!(LogFormat::Text.to_string(), "text");
+/// assert_eq!(LogFormat::Json.to_string(), "json");
+/// ```
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum LogFormat {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -16,7 +16,14 @@ pub struct Logger {
 }
 
 impl Logger {
-    /// Create a new logger
+    /// Create a new logger.
+    ///
+    /// ```
+    /// use kubernix::{LogFormat, Logger};
+    /// use log::LevelFilter;
+    ///
+    /// let logger = Logger::new(LevelFilter::Info, LogFormat::Text);
+    /// ```
     pub fn new(level: LevelFilter, format: LogFormat) -> Box<Self> {
         set_max_level(LevelFilter::Trace);
         Self { level, format }.into()
@@ -26,6 +33,12 @@ impl Logger {
     ///
     /// This is used for fatal errors before the global logger is
     /// configured, so it writes plain text regardless of format settings.
+    ///
+    /// ```
+    /// use kubernix::Logger;
+    ///
+    /// Logger::error("something went wrong");
+    /// ```
     pub fn error(msg: &str) {
         writeln!(stderr(), "[ERROR] {}", msg).ok();
     }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -184,26 +184,6 @@ impl Nix {
     pub fn is_active() -> bool {
         var(Nix::NIX_ENV).is_ok()
     }
-
-    /// Set the NIX_ENV marker so re-exec knows we are inside Nix.
-    ///
-    /// # Safety
-    /// Callers must ensure no other threads are concurrently reading
-    /// or writing environment variables.
-    #[cfg(test)]
-    pub fn set_env_marker() {
-        unsafe { std::env::set_var(Self::NIX_ENV, "true") };
-    }
-
-    /// Remove the NIX_ENV marker.
-    ///
-    /// # Safety
-    /// Callers must ensure no other threads are concurrently reading
-    /// or writing environment variables.
-    #[cfg(test)]
-    pub fn remove_env_marker() {
-        unsafe { std::env::remove_var(Self::NIX_ENV) };
-    }
 }
 
 #[cfg(test)]
@@ -272,15 +252,13 @@ mod tests {
         assert!(parsed["nodes"]["nixpkgs"]["locked"]["rev"].is_string());
     }
 
-    /// Tests env marker set/unset in a single test to avoid racing
-    /// on the shared IN_NIX environment variable in parallel runs.
     #[test]
     fn is_active_toggle() {
-        Nix::remove_env_marker();
-        assert!(!Nix::is_active());
-        Nix::set_env_marker();
-        assert!(Nix::is_active());
-        Nix::remove_env_marker();
-        assert!(!Nix::is_active());
+        temp_env::with_var(Nix::NIX_ENV, None::<&str>, || {
+            assert!(!Nix::is_active());
+        });
+        temp_env::with_var(Nix::NIX_ENV, Some("true"), || {
+            assert!(Nix::is_active());
+        });
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -188,18 +188,9 @@ impl System {
 mod tests {
     use super::*;
     use crate::config::tests::test_config;
-    use std::env::set_var;
 
     const VALID_EXECUTABLE: &str = "echo";
     const INVALID_EXECUTABLE: &str = "should-not-exist";
-
-    /// Set an environment variable for testing.
-    ///
-    /// # Safety justification
-    /// Only called from serial unit tests.
-    fn set_test_env(key: &str, value: &str) {
-        unsafe { set_var(key, value) };
-    }
 
     #[test]
     fn module_failure() {
@@ -223,8 +214,9 @@ mod tests {
 
     #[test]
     fn find_shell_success() {
-        set_test_env("SHELL", VALID_EXECUTABLE);
-        assert!(System::shell().is_ok());
+        temp_env::with_var("SHELL", Some(VALID_EXECUTABLE), || {
+            assert!(System::shell().is_ok());
+        });
     }
 
     /// Integration test: requires root for modprobe/sysctl.


### PR DESCRIPTION
- Fix outdated etcd version in README example (3.6.9 -> 3.6.11)
- Add boot phase architecture diagram to README
- Add rustdoc examples for `LogFormat`, `Logger::new`, `Logger::error`
- Replace all `unsafe set_var` usage with `temp-env` crate in tests