### PR TITLE
Consolidate constants, reduce boilerplate, and improve tests

### DIFF
--- a/src/apiserver.rs
+++ b/src/apiserver.rs
@@ -10,7 +10,7 @@ use crate::{
     kubectl::Kubectl,
     network::Network,
     pki::Pki,
-    process::{Process, ProcessState, Stoppable},
+    process::{Process, ProcessState, stoppable},
     write_if_changed,
 };
 use anyhow::{Context, Result};
@@ -123,11 +123,7 @@ impl ApiServer {
     }
 }
 
-impl Stoppable for ApiServer {
-    fn stop(&mut self) -> Result<()> {
-        self.process.stop()
-    }
-}
+stoppable!(ApiServer);
 
 #[cfg(test)]
 mod tests {

--- a/src/component.rs
+++ b/src/component.rs
@@ -234,4 +234,11 @@ mod tests {
         let reg = ComponentRegistry::new();
         assert!(reg.by_phase().is_empty());
     }
+
+    #[test]
+    fn phase_ordering() {
+        assert!(Phase::Infrastructure < Phase::ControlPlane);
+        assert!(Phase::ControlPlane < Phase::Controller);
+        assert!(Phase::Controller < Phase::NodeAgent);
+    }
 }

--- a/src/controllermanager.rs
+++ b/src/controllermanager.rs
@@ -9,9 +9,8 @@ use crate::{
     kubeconfig::KubeConfig,
     network::Network,
     pki::Pki,
-    process::{Process, ProcessState, Stoppable},
+    process::{Process, ProcessState, stoppable},
 };
-use anyhow::Result;
 use std::fs::create_dir_all;
 
 /// Component wrapper for registry-based startup.
@@ -75,11 +74,7 @@ impl ControllerManager {
     }
 }
 
-impl Stoppable for ControllerManager {
-    fn stop(&mut self) -> Result<()> {
-        self.process.stop()
-    }
-}
+stoppable!(ControllerManager);
 
 #[cfg(test)]
 mod tests {

--- a/src/coredns.rs
+++ b/src/coredns.rs
@@ -48,4 +48,15 @@ mod tests {
         assert!(yml.contains("clusterIP: 10.10.1.2"));
         assert!(yml.contains("k8s-app: coredns"));
     }
+
+    #[test]
+    fn render_contains_resource_kinds() {
+        let yml = CoreDns::render(Ipv4Addr::new(10, 0, 0, 2));
+        assert!(yml.contains("kind: ServiceAccount"));
+        assert!(yml.contains("kind: ClusterRole"));
+        assert!(yml.contains("kind: ClusterRoleBinding"));
+        assert!(yml.contains("kind: ConfigMap"));
+        assert!(yml.contains("kind: Deployment"));
+        assert!(yml.contains("kind: Service"));
+    }
 }

--- a/src/etcd.rs
+++ b/src/etcd.rs
@@ -8,9 +8,8 @@ use crate::{
     config::Config,
     network::Network,
     pki::Pki,
-    process::{Process, ProcessState, Stoppable},
+    process::{Process, ProcessState, stoppable},
 };
-use anyhow::Result;
 use std::fs::create_dir_all;
 
 /// Component wrapper for registry-based startup.
@@ -78,16 +77,13 @@ impl Etcd {
     }
 }
 
-impl Stoppable for Etcd {
-    fn stop(&mut self) -> Result<()> {
-        self.process.stop()
-    }
-}
+stoppable!(Etcd);
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{config::tests::test_config, network::tests::test_network};
+    use anyhow::Result;
 
     #[test]
     fn component_metadata() {

--- a/src/kubeconfig.rs
+++ b/src/kubeconfig.rs
@@ -83,40 +83,40 @@ impl KubeConfig {
 
             // Generate all kubeconfig files in parallel since they are
             // independent of each other.
-            let (left, right) = rayon::join(
+            let identities = [
+                pki.proxy(),
+                pki.controller_manager(),
+                pki.scheduler(),
+                pki.admin(),
+            ];
+            let (configs, kubelets) = rayon::join(
                 || {
-                    rayon::join(
-                        || Self::setup_kubeconfig(&dir, pki.proxy(), ca),
-                        || Self::setup_kubeconfig(&dir, pki.controller_manager(), ca),
-                    )
+                    identities
+                        .into_par_iter()
+                        .map(|id| Self::setup_kubeconfig(&dir, id, ca))
+                        .collect::<Vec<_>>()
                 },
                 || {
-                    rayon::join(
-                        || {
-                            rayon::join(
-                                || Self::setup_kubeconfig(&dir, pki.scheduler(), ca),
-                                || Self::setup_kubeconfig(&dir, pki.admin(), ca),
-                            )
-                        },
-                        || {
-                            pki.kubelets()
-                                .par_iter()
-                                .map(|id| Self::setup_kubeconfig(&dir, id, ca))
-                                .collect::<Result<Vec<_>, _>>()
-                        },
-                    )
+                    pki.kubelets()
+                        .par_iter()
+                        .map(|id| Self::setup_kubeconfig(&dir, id, ca))
+                        .collect::<Result<Vec<_>>>()
                 },
             );
 
-            let (proxy, controller_manager) = left;
-            let ((scheduler, admin), kubelets) = right;
+            let mut it = configs.into_iter();
+            let proxy = it.next().unwrap()?;
+            let controller_manager = it.next().unwrap()?;
+            let scheduler = it.next().unwrap()?;
+            let admin = it.next().unwrap()?;
+            debug_assert!(it.next().is_none());
 
             Ok(KubeConfig {
+                proxy,
+                controller_manager,
+                scheduler,
+                admin,
                 kubelets: kubelets?,
-                proxy: proxy?,
-                controller_manager: controller_manager?,
-                scheduler: scheduler?,
-                admin: admin?,
             })
         }
     }

--- a/src/kubectl.rs
+++ b/src/kubectl.rs
@@ -3,6 +3,7 @@
 //! Provides a typed interface around the `kubectl` binary for applying
 //! manifests, configuring kubeconfig files, and waiting for pod readiness.
 
+use crate::process::READINESS_TIMEOUT;
 use anyhow::{Result, bail};
 use log::{debug, trace};
 use std::{
@@ -64,9 +65,8 @@ impl Kubectl {
     /// Wait for a pod to be ready
     pub fn wait_ready(&self, name: &str) -> Result<()> {
         debug!("Waiting for {} to be ready", name);
-        const TIMEOUT: u64 = 120;
         let now = Instant::now();
-        while now.elapsed().as_secs() < TIMEOUT {
+        while now.elapsed().as_secs() < READINESS_TIMEOUT {
             let output = self.execute(&[
                 "get",
                 "pods",
@@ -81,7 +81,7 @@ impl Kubectl {
                     name,
                     status,
                     now.elapsed().as_secs(),
-                    TIMEOUT,
+                    READINESS_TIMEOUT,
                 );
                 if stdout.contains("1/1") {
                     debug!("{} ready", name);
@@ -92,7 +92,7 @@ impl Kubectl {
                     "{} status not available ({}/{}s)",
                     name,
                     now.elapsed().as_secs(),
-                    TIMEOUT,
+                    READINESS_TIMEOUT,
                 )
             }
             sleep(Duration::from_secs(2));
@@ -111,5 +111,12 @@ mod tests {
         let k = Kubectl::new(&PathBuf::from(""));
         k.execute(&[])?;
         Ok(())
+    }
+
+    #[test]
+    fn kubeconfig_path() {
+        let path = PathBuf::from("/tmp/test.kubeconfig");
+        let k = Kubectl::new(&path);
+        assert_eq!(k.kubeconfig(), path);
     }
 }

--- a/src/kubelet.rs
+++ b/src/kubelet.rs
@@ -12,11 +12,14 @@ use crate::{
     network::Network,
     node::Node,
     pki::Pki,
-    process::{Process, ProcessState, Stoppable},
+    process::{Process, ProcessState, stoppable},
     write_if_changed,
 };
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, bail};
 use std::fs::create_dir_all;
+
+const KUBELET_PORT_BASE: u16 = 11250;
+const HEALTHZ_PORT_BASE: u16 = 12250;
 
 /// Component wrapper for registry-based startup (per-node).
 pub struct KubeletComponent {
@@ -94,8 +97,8 @@ impl Kubelet {
                 .context("Unable to retrieve kubelet CIDR")?,
             cert = identity.cert().display(),
             key = identity.key().display(),
-            port = 11250 + u16::from(node),
-            healthzPort = 12250 + u16::from(node),
+            port = KUBELET_PORT_BASE + u16::from(node),
+            healthzPort = HEALTHZ_PORT_BASE + u16::from(node),
         );
         let cfg = dir.join("config.yml");
         write_if_changed(&cfg, &yml)?;
@@ -143,11 +146,7 @@ impl Kubelet {
     }
 }
 
-impl Stoppable for Kubelet {
-    fn stop(&mut self) -> Result<()> {
-        self.process.stop()
-    }
-}
+stoppable!(Kubelet);
 
 #[cfg(test)]
 mod tests {
@@ -163,16 +162,16 @@ mod tests {
             cidr = "10.10.128.0/18",
             cert = "/tmp/kubelet.pem",
             key = "/tmp/kubelet-key.pem",
-            port = 11250,
-            healthzPort = 12250,
+            port = KUBELET_PORT_BASE,
+            healthzPort = HEALTHZ_PORT_BASE,
         );
         assert!(yml.contains("kind: KubeletConfiguration"));
         assert!(yml.contains("clientCAFile: \"/tmp/ca.pem\""));
         assert!(yml.contains("clusterDNS:"));
         assert!(yml.contains("- \"10.10.64.2\""));
         assert!(yml.contains("podCIDR: \"10.10.128.0/18\""));
-        assert!(yml.contains("port: 11250"));
-        assert!(yml.contains("healthzPort: 12250"));
+        assert!(yml.contains(&format!("port: {}", KUBELET_PORT_BASE)));
+        assert!(yml.contains(&format!("healthzPort: {}", HEALTHZ_PORT_BASE)));
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -45,4 +45,11 @@ mod tests {
         assert_eq!(Node::name(&c, &n, 0), *n.hostname());
         Ok(())
     }
+
+    #[test]
+    fn multi_node_names_are_unique() {
+        use std::collections::HashSet;
+        let names: HashSet<String> = (0..5).map(Node::raw).collect();
+        assert_eq!(names.len(), 5);
+    }
 }

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -16,6 +16,9 @@ use std::{
     process::{Command, Stdio},
 };
 
+const RSA_KEY_SIZE: u32 = 2048;
+const CERT_EXPIRY: &str = "8760h";
+
 #[must_use]
 pub struct Pki {
     admin: Identity,
@@ -224,52 +227,48 @@ impl Pki {
                 vec![network.hostname()]
             };
 
-            let (left, right) = rayon::join(
+            type CertFn = fn(&PkiConfig) -> Result<Identity>;
+            let cert_fns: [CertFn; 6] = [
+                Self::setup_admin,
+                Self::setup_apiserver,
+                Self::setup_controller_manager,
+                Self::setup_proxy,
+                Self::setup_scheduler,
+                Self::setup_service_account,
+            ];
+
+            let (certs, kubelets) = rayon::join(
                 || {
-                    rayon::join(
-                        || {
-                            rayon::join(
-                                || Self::setup_admin(pki_config),
-                                || Self::setup_apiserver(pki_config),
-                            )
-                        },
-                        || {
-                            rayon::join(
-                                || Self::setup_controller_manager(pki_config),
-                                || Self::setup_proxy(pki_config),
-                            )
-                        },
-                    )
+                    cert_fns
+                        .into_par_iter()
+                        .map(|f| f(pki_config))
+                        .collect::<Vec<_>>()
                 },
                 || {
-                    rayon::join(
-                        || {
-                            rayon::join(
-                                || Self::setup_scheduler(pki_config),
-                                || Self::setup_service_account(pki_config),
-                            )
-                        },
-                        || {
-                            kubelet_nodes
-                                .par_iter()
-                                .map(|n| Self::setup_kubelet(pki_config, n))
-                                .collect::<Result<Vec<_>, _>>()
-                        },
-                    )
+                    kubelet_nodes
+                        .par_iter()
+                        .map(|n| Self::setup_kubelet(pki_config, n))
+                        .collect::<Result<Vec<_>>>()
                 },
             );
 
-            let ((admin, apiserver), (controller_manager, proxy)) = left;
-            let ((scheduler, service_account), kubelets) = right;
+            let mut it = certs.into_iter();
+            let admin = it.next().unwrap()?;
+            let apiserver = it.next().unwrap()?;
+            let controller_manager = it.next().unwrap()?;
+            let proxy = it.next().unwrap()?;
+            let scheduler = it.next().unwrap()?;
+            let service_account = it.next().unwrap()?;
+            debug_assert!(it.next().is_none());
 
             Ok(Pki {
-                admin: admin?,
-                apiserver: apiserver?,
-                controller_manager: controller_manager?,
+                admin,
+                apiserver,
+                controller_manager,
+                proxy,
+                scheduler,
+                service_account,
                 kubelets: kubelets?,
-                proxy: proxy?,
-                scheduler: scheduler?,
-                service_account: service_account?,
                 ca,
             })
         }
@@ -398,7 +397,7 @@ impl Pki {
             "CN": cn,
             "key": {
                 "algo": "rsa",
-                "size": 2048
+                "size": RSA_KEY_SIZE
             },
             "names": [{
                 "O": o,
@@ -413,7 +412,7 @@ impl Pki {
         let cfg = json!({
             "signing": {
                 "default": {
-                    "expiry": "8760h"
+                    "expiry": CERT_EXPIRY
                 },
                 "profiles": {
                     "kubernetes": {
@@ -423,7 +422,7 @@ impl Pki {
                             "server auth",
                             "client auth"
                         ],
-                        "expiry": "8760h"
+                        "expiry": CERT_EXPIRY
                     }
                 }
             }

--- a/src/process.rs
+++ b/src/process.rs
@@ -49,6 +49,20 @@ pub type Stoppables = Vec<Started>;
 /// The result of starting a component process, either a stoppable handle or an error.
 pub type ProcessState = Result<Started>;
 
+/// Default timeout in seconds for process readiness and pod polling.
+pub const READINESS_TIMEOUT: u64 = 120;
+
+macro_rules! stoppable {
+    ($ty:ty) => {
+        impl $crate::process::Stoppable for $ty {
+            fn stop(&mut self) -> anyhow::Result<()> {
+                self.process.stop()
+            }
+        }
+    };
+}
+pub(crate) use stoppable;
+
 #[derive(Deserialize, Serialize)]
 struct Run {
     command: PathBuf,
@@ -132,7 +146,7 @@ impl Process {
             log_file,
             name: identifier.into(),
             pid,
-            readiness_timeout: 120,
+            readiness_timeout: READINESS_TIMEOUT,
             watch: Some(watch),
         })
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -9,10 +9,9 @@ use crate::{
     kubeconfig::KubeConfig,
     network::Network,
     node::Node,
-    process::{Process, ProcessState, Stoppable},
+    process::{Process, ProcessState, stoppable},
     write_if_changed,
 };
-use anyhow::Result;
 use std::fs::create_dir_all;
 
 /// Component wrapper for registry-based startup.
@@ -75,11 +74,7 @@ impl Proxy {
     }
 }
 
-impl Stoppable for Proxy {
-    fn stop(&mut self) -> Result<()> {
-        self.process.stop()
-    }
-}
+stoppable!(Proxy);
 
 #[cfg(test)]
 mod tests {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -7,10 +7,9 @@ use crate::{
     component::{ClusterContext, Component, Phase},
     config::Config,
     kubeconfig::KubeConfig,
-    process::{Process, ProcessState, Stoppable},
+    process::{Process, ProcessState, stoppable},
     write_if_changed,
 };
-use anyhow::Result;
 use std::fs::create_dir_all;
 
 /// Component wrapper for registry-based startup.
@@ -60,11 +59,7 @@ impl Scheduler {
     }
 }
 
-impl Stoppable for Scheduler {
-    fn stop(&mut self) -> Result<()> {
-        self.process.stop()
-    }
-}
+stoppable!(Scheduler);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
- Extract shared constants: `READINESS_TIMEOUT` in `process.rs` (used by `kubectl.rs`), `KUBELET_PORT_BASE`/`HEALTHZ_PORT_BASE` in `kubelet.rs`, `RSA_KEY_SIZE`/`CERT_EXPIRY` in `pki.rs`
- Add `stoppable!` macro in `process.rs` to replace identical `Stoppable` implementations across 6 component files
- Flatten deeply nested `rayon::join` chains into `par_iter` in `pki.rs` and `kubeconfig.rs` for readability
- Add tests for phase ordering, kubectl path storage, CoreDNS resource kinds, multi-node naming, and kubelet port constants