### PR TITLE
Update nixpkgs to Kubernetes v1.36.2 and bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,19 +329,18 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "kubernix"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -750,9 +749,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -763,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -773,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -786,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubernix"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Sascha Grunert <mail@saschagrunert.de>"]
 edition = "2024"
 rust-version = "1.88"

--- a/README.md
+++ b/README.md
@@ -43,23 +43,23 @@ The following technology stack is currently being used:
 | Application     | Version  |
 | --------------- | -------- |
 | cfssl           | v1.6.5   |
-| cni-plugins     | v1.9.0   |
+| cni-plugins     | v1.9.1   |
 | conmon          | v2.2.1   |
 | conntrack-tools | v1.4.8   |
-| cri-o-wrapper   | v1.36.0  |
+| cri-o-wrapper   | v1.36.2  |
 | cri-tools       | v1.36.0  |
 | crun            | v1.27.1  |
-| etcd            | v3.6.11  |
-| iproute2        | v6.19.0  |
+| etcd            | v3.6.13  |
+| iproute2        | v7.1.0   |
 | iptables        | v1.8.13  |
 | kmod            | v31      |
-| kubectl         | v1.36.1  |
-| kubernetes      | v1.36.1  |
-| nss-cacert      | v3.121   |
-| podman          | v5.8.2   |
-| socat           | v1.8.1.1 |
+| kubectl         | v1.36.2  |
+| kubernetes      | v1.36.2  |
+| nss-cacert      | v3.125   |
+| podman          | v5.8.4   |
+| socat           | v1.8.1.3 |
 | sysctl          | v4.0.6   |
-| util-linux      | v2.42    |
+| util-linux      | v2.42.2  |
 
 Some other tools are not explicitly mentioned here, because they are no
 first-level dependencies.
@@ -291,8 +291,8 @@ $ sudo kubernix --overlay overlay.nix
 [INFO ] Nix environment not found, bootstrapping one
 [INFO ] Using custom overlay 'overlay.nix'
 these derivations will be built:
-  /nix/store/…-cri-o-1.36.0.drv
-  building '/nix/store/…-cri-o-1.36.0.drv'...
+  /nix/store/…-cri-o-1.36.2.drv
+  building '/nix/store/…-cri-o-1.36.2.drv'...
 ```
 
 Using this technique makes it easy for daily development of Kubernetes

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779259093,
-        "narHash": "sha256-7DKWmH23hL2eYdkxCKeqj2i+yljTKuU+3Nk1UPHOnxc=",
+        "lastModified": 1784115452,
+        "narHash": "sha256-BoYPdqk6jlKXy+DyUzyGV/CtRGfAhk2MmIgBhsemTGI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d99b013d5d1931ad77fe3912ed218170dec5d9a4",
+        "rev": "35d3407a3816f3b341d8cf1d60abaf2b7b8166ac",
         "type": "github"
       },
       "original": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -353,36 +353,46 @@ pub mod tests {
 
     #[test]
     fn canonicalize_root_success() -> Result<()> {
-        let mut c = Config::default();
-        c.root = tempdir()?.keep();
+        let mut c = Config {
+            root: tempdir()?.keep(),
+            ..Config::default()
+        };
         c.canonicalize_root()
     }
 
     #[test]
     fn canonicalize_root_failure() {
-        let mut c = Config::default();
-        c.root = Path::new("/").join("proc").join("invalid");
+        let mut c = Config {
+            root: Path::new("/").join("proc").join("invalid"),
+            ..Config::default()
+        };
         assert!(c.canonicalize_root().is_err())
     }
 
     #[test]
     fn to_file_success() -> Result<()> {
-        let mut c = Config::default();
-        c.root = tempdir()?.keep();
+        let c = Config {
+            root: tempdir()?.keep(),
+            ..Config::default()
+        };
         c.to_file()
     }
 
     #[test]
     fn to_file_failure() {
-        let mut c = Config::default();
-        c.root = Path::new("/").join("proc").join("invalid");
+        let c = Config {
+            root: Path::new("/").join("proc").join("invalid"),
+            ..Config::default()
+        };
         assert!(c.to_file().is_err())
     }
 
     #[test]
     fn try_load_file_success() -> Result<()> {
-        let mut c = Config::default();
-        c.root = tempdir()?.keep();
+        let mut c = Config {
+            root: tempdir()?.keep(),
+            ..Config::default()
+        };
         fs::write(
             c.root.join(Config::FILENAME),
             r#"
@@ -408,8 +418,10 @@ root = "root"
 
     #[test]
     fn try_load_file_with_dockerfile() -> Result<()> {
-        let mut c = Config::default();
-        c.root = tempdir()?.keep();
+        let mut c = Config {
+            root: tempdir()?.keep(),
+            ..Config::default()
+        };
         fs::write(
             c.root.join(Config::FILENAME),
             r#"
@@ -433,8 +445,10 @@ root = "root"
 
     #[test]
     fn try_load_file_failure() -> Result<()> {
-        let mut c = Config::default();
-        c.root = tempdir()?.keep();
+        let mut c = Config {
+            root: tempdir()?.keep(),
+            ..Config::default()
+        };
         fs::write(c.root.join(Config::FILENAME), "invalid")?;
         assert!(c.try_load_file().is_err());
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,39 @@ impl Kubernix {
     }
 }
 
+impl Drop for Kubernix {
+    fn drop(&mut self) {
+        let p = Progress::new(Self::processes(&self.config), self.config.log_level());
+
+        info!("Cleaning up");
+
+        // Signal the addon thread to stop and give it a short window
+        // to finish. If it does not complete in time, proceed with
+        // shutdown rather than blocking for up to 120s.
+        self.addon_shutdown.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.addon_thread.take() {
+            debug!("Waiting for addon deployment to finish");
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while !handle.is_finished() && Instant::now() < deadline {
+                sleep(Duration::from_millis(100));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            } else {
+                debug!("Addon thread did not finish in time, proceeding with shutdown");
+            }
+        }
+
+        self.stop();
+        self.umount();
+        self.system.cleanup();
+        info!("Cleanup done");
+
+        p.reset();
+        debug!("All done");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -447,38 +480,5 @@ mod tests {
         let dir = tempdir().unwrap();
         let points = Kubernix::read_mount_points(dir.path()).unwrap();
         assert!(points.is_empty());
-    }
-}
-
-impl Drop for Kubernix {
-    fn drop(&mut self) {
-        let p = Progress::new(Self::processes(&self.config), self.config.log_level());
-
-        info!("Cleaning up");
-
-        // Signal the addon thread to stop and give it a short window
-        // to finish. If it does not complete in time, proceed with
-        // shutdown rather than blocking for up to 120s.
-        self.addon_shutdown.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.addon_thread.take() {
-            debug!("Waiting for addon deployment to finish");
-            let deadline = Instant::now() + Duration::from_secs(5);
-            while !handle.is_finished() && Instant::now() < deadline {
-                sleep(Duration::from_millis(100));
-            }
-            if handle.is_finished() {
-                let _ = handle.join();
-            } else {
-                debug!("Addon thread did not finish in time, proceeding with shutdown");
-            }
-        }
-
-        self.stop();
-        self.umount();
-        self.system.cleanup();
-        info!("Cleanup done");
-
-        p.reset();
-        debug!("All done");
     }
 }


### PR DESCRIPTION
Update nixpkgs pin and all Rust dependencies to their latest versions.
Fix new clippy lints introduced in Rust 1.97.

Notable version bumps:
- Kubernetes/kubectl: 1.36.1 -> 1.36.2
- CRI-O: 1.36.0 -> 1.36.2
- etcd: 3.6.11 -> 3.6.13
- podman: 5.8.2 -> 5.8.4
- iproute2: 6.19.0 -> 7.1.0
- cni-plugins: 1.9.0 -> 1.9.1
- nss-cacert: 3.121 -> 3.125