### PR TITLE
Add containerd as alternative CRI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,17 +251,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-integration:
-    name: test / integration / ${{ matrix.name }}
+    name: test / integration / ${{ matrix.cri_runtime }} / ${{ matrix.mode }}
     runs-on: ubuntu-latest
     needs: build-cross
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: single
+          - mode: single
             nodes: 1
-          - name: multi
+            cri_runtime: crio
+          - mode: multi
             nodes: 2
+            cri_runtime: crio
+          - mode: single
+            nodes: 1
+            cri_runtime: containerd
+          - mode: multi
+            nodes: 2
+            cri_runtime: containerd
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
@@ -278,9 +286,9 @@ jobs:
           sudo hostnamectl set-hostname test
       - name: Prepare the system
         run: sudo contrib/prepare-system
-      - name: Run ${{ matrix.name }} integration test
+      - name: Run ${{ matrix.cri_runtime }} / ${{ matrix.mode }} integration test
         run: |
-          sudo -E env "PATH=$PATH" ./kubernix --log-level=debug --no-shell --addons --nodes=${{ matrix.nodes }} &
+          sudo -E env "PATH=$PATH" ./kubernix --log-level=debug --no-shell --addons --nodes=${{ matrix.nodes }} --cri-runtime=${{ matrix.cri_runtime }} &
           KUBERNIX_PID=$!
           timeout 300 bash -c 'while [ ! -f kubernix-run/kubernix.pid ]; do sleep 1; done'
           echo "Cluster is up, running checks"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following technology stack is currently being used:
 | cni-plugins     | v1.9.1   |
 | conmon          | v2.2.1   |
 | conntrack-tools | v1.4.8   |
+| containerd      | v2.3.1   |
 | cri-o-wrapper   | v1.36.2  |
 | cri-tools       | v1.36.0  |
 | crun            | v1.27.1  |
@@ -78,7 +79,7 @@ graph TD
 
     A --- etcd
     B --- apiserver
-    C --- scheduler & controller-manager & cri-o["cri-o (x N)"] & proxy
+    C --- scheduler & controller-manager & cri["cri-o or containerd (x N)"] & proxy
     D --- kubelet["kubelet (x N)"]
 ```
 
@@ -153,7 +154,7 @@ the current one:
 apiserver/
 controllermanager/
 coredns/
-crio/
+crio/          # or containerd/ when using --cri-runtime=containerd
 encryptionconfig/
 etcd/
 kubeconfig/
@@ -174,7 +175,7 @@ available within their corresponding directory:
 > ls -1 **.log
 apiserver/kube-apiserver.log
 controllermanager/kube-controller-manager.log
-crio/crio.log
+crio/crio.log  # or containerd/ when using --cri-runtime=containerd
 etcd/etcd.log
 kubelet/kubelet.log
 proxy/kube-proxy.log
@@ -254,6 +255,7 @@ KuberNix has some configuration possibilities, which are currently:
 | `-o, --overlay`           | Nix package overlay to be used                                                      |                | `KUBERNIX_OVERLAY`           |
 | `-d, --dockerfile`        | Custom Dockerfile for multi-node container image builds                             |                | `KUBERNIX_DOCKERFILE`        |
 | `-p, --packages`          | Additional Nix dependencies to be added to the environment                          |                | `KUBERNIX_PACKAGES`          |
+| `--cri-runtime`           | CRI runtime to use (`crio` or `containerd`)                                         | `crio`         | `KUBERNIX_CRI_RUNTIME`       |
 | `-a, --addons`            | Cluster addons to deploy (available: coredns)                                       | `coredns`      | `KUBERNIX_ADDONS`            |
 
 Please ensure that the CIDR is not overlapping with existing local networks and

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784115452,
-        "narHash": "sha256-BoYPdqk6jlKXy+DyUzyGV/CtRGfAhk2MmIgBhsemTGI=",
+        "lastModified": 1784555310,
+        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "35d3407a3816f3b341d8cf1d60abaf2b7b8166ac",
+        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
         "type": "github"
       },
       "original": {

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -6,6 +6,7 @@ with pkgs;
   cni-plugins
   conmon
   conntrack-tools
+  containerd
   cri-o
   cri-tools
   etcd

--- a/src/assets/containerd.toml
+++ b/src/assets/containerd.toml
@@ -1,0 +1,27 @@
+version = 3
+root = "{root}"
+state = "{state}"
+
+[grpc]
+address = "{socket}"
+
+[plugins."io.containerd.cri.v1.images"]
+sandbox_image = "registry.k8s.io/pause:3.10"
+
+[plugins."io.containerd.cri.v1.runtime"]
+enable_unprivileged_ports = true
+enable_unprivileged_icmp = true
+
+[plugins."io.containerd.cri.v1.runtime".cni]
+bin_dirs = ["{plugin_dir}"]
+conf_dir = "{cni_conf_dir}"
+
+[plugins."io.containerd.cri.v1.runtime".containerd]
+default_runtime_name = "crun"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.crun]
+runtime_type = "io.containerd.runc.v2"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.crun.options]
+BinaryName = "{runtime_path}"
+SystemdCgroup = false

--- a/src/component.rs
+++ b/src/component.rs
@@ -20,7 +20,8 @@ use rayon::prelude::*;
 /// Components in the same phase start concurrently; phases run sequentially.
 ///
 /// Phase ordering is optimized so that independent components overlap:
-/// - CRI-O starts alongside controllers (it only needs etcd/apiserver, not controllers)
+/// - The CRI runtime (CRI-O or containerd) starts alongside controllers
+///   (it only needs etcd/apiserver, not controllers)
 /// - Proxy starts alongside kubelets (it only needs the API server to sync caches)
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Phase {
@@ -30,9 +31,9 @@ pub enum Phase {
     ControlPlane,
     /// Controllers, node runtimes, and proxy all start together since they
     /// only depend on the API server, not on each other.
-    /// Contains: scheduler, controller-manager, CRI-O (per node), proxy.
+    /// Contains: scheduler, controller-manager, CRI runtime (per node), proxy.
     Controller,
-    /// Node agents that require a running CRI-O runtime (kubelet).
+    /// Node agents that require a running CRI runtime (kubelet).
     NodeAgent,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,33 @@ impl fmt::Display for LogFormat {
     }
 }
 
+/// Container Runtime Interface (CRI) implementation to use.
+///
+/// ```
+/// use kubernix::CriRuntime;
+///
+/// assert_eq!(CriRuntime::Crio.to_string(), "crio");
+/// assert_eq!(CriRuntime::Containerd.to_string(), "containerd");
+/// ```
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum CriRuntime {
+    /// CRI-O container runtime (default)
+    #[default]
+    Crio,
+    /// containerd container runtime
+    Containerd,
+}
+
+impl fmt::Display for CriRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CriRuntime::Crio => write!(f, "crio"),
+            CriRuntime::Containerd => write!(f, "containerd"),
+        }
+    }
+}
+
 #[derive(Clone, Parser, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[command(
@@ -164,6 +191,16 @@ pub struct Config {
     /// Custom Dockerfile path for multi-node container image builds
     dockerfile: Option<PathBuf>,
 
+    #[serde(default)]
+    #[arg(
+        default_value = "crio",
+        env = "KUBERNIX_CRI_RUNTIME",
+        long = "cri-runtime",
+        value_name = "CRI_RUNTIME"
+    )]
+    /// The CRI runtime to use (crio or containerd)
+    cri_runtime: CriRuntime,
+
     #[arg(
         default_value = "coredns",
         env = "KUBERNIX_ADDONS",
@@ -235,6 +272,11 @@ impl Config {
     /// Custom Dockerfile path for multi-node container image builds.
     pub fn dockerfile(&self) -> Option<&Path> {
         self.dockerfile.as_deref()
+    }
+
+    /// CRI runtime implementation (CRI-O or containerd).
+    pub fn cri_runtime(&self) -> CriRuntime {
+        self.cri_runtime
     }
 
     /// Cluster addons to deploy after bootstrap (e.g. `coredns`).
@@ -399,6 +441,7 @@ pub mod tests {
 addons = ["coredns"]
 cidr = "1.1.1.1/16"
 container-runtime = "podman"
+cri-runtime = "crio"
 log-format = "text"
 log-level = "DEBUG"
 no-shell = false
@@ -412,6 +455,7 @@ root = "root"
         assert_eq!(c.log_level(), LevelFilter::Debug);
         assert_eq!(c.log_format(), LogFormat::Text);
         assert_eq!(&c.cidr().to_string(), "1.1.1.1/16");
+        assert_eq!(c.cri_runtime(), CriRuntime::Crio);
         assert!(c.dockerfile().is_none());
         Ok(())
     }
@@ -428,6 +472,7 @@ root = "root"
 addons = ["coredns"]
 cidr = "1.1.1.1/16"
 container-runtime = "podman"
+cri-runtime = "containerd"
 dockerfile = "/tmp/MyDockerfile"
 log-format = "json"
 log-level = "DEBUG"
@@ -439,7 +484,33 @@ root = "root"
         )?;
         c.try_load_file()?;
         assert_eq!(c.log_format(), LogFormat::Json);
+        assert_eq!(c.cri_runtime(), CriRuntime::Containerd);
         assert_eq!(c.dockerfile(), Some(Path::new("/tmp/MyDockerfile")));
+        Ok(())
+    }
+
+    #[test]
+    fn try_load_file_without_cri_runtime() -> Result<()> {
+        let mut c = Config {
+            root: tempdir()?.keep(),
+            ..Config::default()
+        };
+        fs::write(
+            c.root.join(Config::FILENAME),
+            r#"
+addons = ["coredns"]
+cidr = "1.1.1.1/16"
+container-runtime = "podman"
+log-format = "text"
+log-level = "DEBUG"
+no-shell = false
+nodes = 1
+packages = []
+root = "root"
+            "#,
+        )?;
+        c.try_load_file()?;
+        assert_eq!(c.cri_runtime(), CriRuntime::Crio);
         Ok(())
     }
 

--- a/src/containerd.rs
+++ b/src/containerd.rs
@@ -1,0 +1,190 @@
+//! containerd container runtime component.
+//!
+//! Manages containerd instances that provide the container runtime
+//! interface for kubelet. In multi-node mode, each containerd instance
+//! runs inside its own container with an isolated CNI network
+//! configuration.
+
+use crate::{
+    Config,
+    component::{ClusterContext, Component, Phase},
+    container::Container,
+    cri::{self, CriSocket},
+    network::Network,
+    node::Node,
+    process::{Process, ProcessState, Stoppable},
+    system::System,
+};
+use anyhow::{Context, Result};
+use std::{
+    fs::{self, create_dir_all},
+    path::PathBuf,
+};
+
+/// Component wrapper for registry-based startup (per-node).
+pub struct ContainerdComponent {
+    node: u8,
+    name: String,
+}
+
+impl ContainerdComponent {
+    /// Create a new containerd component for the given node index.
+    pub fn new(node: u8) -> Self {
+        Self {
+            node,
+            name: format!("Containerd (node {})", node),
+        }
+    }
+}
+
+impl Component for ContainerdComponent {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn phase(&self) -> Phase {
+        Phase::Controller
+    }
+
+    fn start(&self, ctx: &ClusterContext<'_>) -> ProcessState {
+        Containerd::start(ctx.config, self.node, ctx.network)
+    }
+}
+
+/// Manages a containerd process and its associated socket for a single node.
+pub struct Containerd {
+    process: Process,
+    socket: CriSocket,
+    node_name: String,
+}
+
+const CONTAINERD: &str = "containerd";
+
+impl Containerd {
+    /// Start a containerd instance for the given node index.
+    pub fn start(config: &Config, node: u8, network: &Network) -> ProcessState {
+        let node_name = Node::name(config, network, node);
+
+        let crun_path: String;
+        let plugin_dir: String;
+        if config.multi_node() {
+            // Use bare binary name so the runc v2 shim resolves crun from $PATH
+            // inside the container (nix-shell provides it).
+            crun_path = "crun".to_string();
+            // Placeholder: patched at container startup time via sed.
+            plugin_dir = "/tmp/cni-plugins".to_string();
+        } else {
+            crun_path = System::find_executable("crun")?.display().to_string();
+            let loopback = System::find_executable("loopback")?;
+            plugin_dir = loopback
+                .parent()
+                .context("Unable to find CNI plugin dir")?
+                .display()
+                .to_string();
+        };
+
+        let dir = Self::path(config, network, node);
+        let config_file = dir.join("config.toml");
+        let cni_conf_dir = dir.join("cni");
+        let socket = Self::socket(config, network, node)?;
+
+        if !dir.exists() {
+            create_dir_all(&dir)?;
+            create_dir_all(&cni_conf_dir)?;
+
+            fs::write(
+                &config_file,
+                format!(
+                    include_str!("assets/containerd.toml"),
+                    root = dir.join("root").display(),
+                    state = dir.join("state").display(),
+                    socket = socket,
+                    plugin_dir = plugin_dir,
+                    cni_conf_dir = cni_conf_dir.display(),
+                    runtime_path = crun_path,
+                ),
+            )?;
+
+            cri::write_cni_config(&cni_conf_dir, &node_name, node, network)?;
+        }
+
+        let config_arg = format!("--config={}", config_file.display());
+        let args: &[&str] = &[&config_arg];
+
+        let mut process = if config.multi_node() {
+            // containerd has no --cni-plugin-dir CLI flag (unlike CRI-O), so
+            // patch bin_dirs in the config before starting the daemon. The
+            // container entrypoint runs all args through `bash -c "$*"`, so
+            // shell constructs (&&, $(...)) are interpreted.
+            let identifier = format!("Containerd {}", node_name);
+            let patch_bin_dirs = format!(
+                r#"sed -i "s|bin_dirs = .*|bin_dirs = [\"$(dirname $(which loopback))\"]|" {} &&"#,
+                config_file.display(),
+            );
+            let container_args: &[&str] = &[CONTAINERD, &config_arg];
+            Container::start(
+                config,
+                &dir,
+                &identifier,
+                &patch_bin_dirs,
+                &node_name,
+                container_args,
+            )?
+        } else {
+            Process::start(&dir, "Containerd", CONTAINERD, args)?
+        };
+        process.wait_ready("containerd successfully booted")?;
+
+        Ok(Box::new(Self {
+            process,
+            socket,
+            node_name,
+        }))
+    }
+
+    /// Retrieve the CRI socket for the given node.
+    pub fn socket(config: &Config, network: &Network, node: u8) -> Result<CriSocket> {
+        CriSocket::new(Self::path(config, network, node).join("containerd.sock"))
+    }
+
+    /// Retrieve the working path for the node.
+    fn path(config: &Config, network: &Network, node: u8) -> PathBuf {
+        config
+            .root()
+            .join(CONTAINERD)
+            .join(Node::name(config, network, node))
+    }
+}
+
+impl Stoppable for Containerd {
+    fn stop(&mut self) -> Result<()> {
+        cri::remove_all_containers("containerd", &self.socket, &self.node_name).with_context(
+            || {
+                format!(
+                    "Unable to remove containerd containers on {}",
+                    self.node_name,
+                )
+            },
+        )?;
+
+        self.process.stop()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_metadata() {
+        let c = ContainerdComponent::new(0);
+        assert_eq!(c.name(), "Containerd (node 0)");
+        assert_eq!(c.phase(), Phase::Controller);
+    }
+
+    #[test]
+    fn component_name_per_node() {
+        assert_eq!(ContainerdComponent::new(0).name(), "Containerd (node 0)");
+        assert_eq!(ContainerdComponent::new(2).name(), "Containerd (node 2)");
+    }
+}

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -1,0 +1,151 @@
+//! Shared CRI (Container Runtime Interface) abstractions.
+//!
+//! Contains types and helpers used by both CRI-O and containerd
+//! implementations.
+
+use crate::{
+    config::{Config, CriRuntime},
+    containerd::Containerd,
+    crio::Crio,
+    network::Network,
+};
+use anyhow::{Context, Result, bail};
+use log::debug;
+use serde_json::{json, to_string_pretty};
+use std::{
+    fmt::{self, Display, Formatter},
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Environment variable name for the CRI socket endpoint.
+pub const RUNTIME_ENV: &str = "CONTAINER_RUNTIME_ENDPOINT";
+
+/// Maximum usable bytes in a Unix socket path (108 - 1 for null terminator).
+pub const MAX_SOCKET_PATH_LEN: usize = 107;
+
+/// Simple CRI socket abstraction.
+pub struct CriSocket(PathBuf);
+
+impl Display for CriSocket {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.display())
+    }
+}
+
+impl CriSocket {
+    /// Create a new CRI socket, validating the path length against Unix limits.
+    pub fn new(path: PathBuf) -> Result<CriSocket> {
+        if path.display().to_string().len() > MAX_SOCKET_PATH_LEN {
+            bail!("Socket path '{}' is too long", path.display())
+        }
+        Ok(CriSocket(path))
+    }
+
+    /// Format the socket path as a `unix://` URI for CRI clients.
+    pub fn to_socket_string(&self) -> String {
+        format!("unix://{}", self.0.display())
+    }
+}
+
+/// Return the CRI socket for the configured runtime and node.
+pub fn cri_socket(config: &Config, network: &Network, node: u8) -> Result<CriSocket> {
+    match config.cri_runtime() {
+        CriRuntime::Crio => Crio::socket(config, network, node),
+        CriRuntime::Containerd => Containerd::socket(config, network, node),
+    }
+}
+
+/// Write the CNI bridge network configuration for a node.
+pub fn write_cni_config(
+    cni_conf_dir: &Path,
+    node_name: &str,
+    node: u8,
+    network: &Network,
+) -> Result<()> {
+    let cidr = network
+        .pod_cidrs()
+        .get(node as usize)
+        .with_context(|| format!("Unable to find CIDR for {}", node_name))?;
+    fs::write(
+        cni_conf_dir.join("10-bridge.json"),
+        to_string_pretty(&json!({
+            "cniVersion": "0.3.1",
+            "name": format!("kubernix-{}", node_name),
+            "type": "bridge",
+            "bridge": format!("{}.{}", Network::INTERFACE_PREFIX, node),
+            "isGateway": true,
+            "ipMasq": true,
+            "hairpinMode": true,
+            "ipam": {
+                "type": "host-local",
+                "routes": [{ "dst": "0.0.0.0/0" }],
+                "ranges": [[{ "subnet": cidr }]]
+            }
+        }))?,
+    )?;
+    Ok(())
+}
+
+/// Remove all containers and pods via crictl.
+pub fn remove_all_containers(label: &str, socket: &CriSocket, node_name: &str) -> Result<()> {
+    debug!("Removing all {} workloads on {}", label, node_name);
+
+    let output = Command::new("crictl")
+        .env(RUNTIME_ENV, socket.to_socket_string())
+        .arg("pods")
+        .arg("-q")
+        .output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    if !output.status.success() {
+        debug!("crictl pods stdout ({}): {}", node_name, stdout);
+        debug!(
+            "crictl pods stderr ({}): {}",
+            node_name,
+            String::from_utf8(output.stderr)?
+        );
+        bail!("crictl pods command failed ({})", node_name);
+    }
+
+    for x in stdout.lines() {
+        debug!("Removing pod {} on {}", x, node_name);
+        let output = Command::new("crictl")
+            .env(RUNTIME_ENV, socket.to_socket_string())
+            .arg("rmp")
+            .arg("-f")
+            .arg(x)
+            .output()?;
+        if !output.status.success() {
+            debug!("crictl rmp ({}): {:?}", node_name, output);
+            bail!("crictl rmp command failed ({})", node_name);
+        }
+    }
+
+    debug!("All workloads removed on {}", node_name);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cri_socket_success() -> Result<()> {
+        CriSocket::new("/some/path.sock".into())?;
+        Ok(())
+    }
+
+    #[test]
+    fn cri_socket_failure() {
+        assert!(CriSocket::new("a".repeat(MAX_SOCKET_PATH_LEN + 1).into()).is_err());
+    }
+
+    #[test]
+    fn cri_socket_string_format() -> Result<()> {
+        let socket = CriSocket::new("/run/crio.sock".into())?;
+        assert_eq!(socket.to_socket_string(), "unix:///run/crio.sock");
+        assert_eq!(socket.to_string(), "/run/crio.sock");
+        Ok(())
+    }
+}

--- a/src/crio.rs
+++ b/src/crio.rs
@@ -5,22 +5,19 @@
 //! own container with an isolated CNI network configuration.
 
 use crate::{
-    Config, RUNTIME_ENV,
+    Config,
     component::{ClusterContext, Component, Phase},
     container::Container,
+    cri::{self, CriSocket},
     network::Network,
     node::Node,
     process::{Process, ProcessState, Stoppable},
     system::System,
 };
-use anyhow::{Context, Result, bail};
-use log::debug;
-use serde_json::{json, to_string_pretty};
+use anyhow::{Context, Result};
 use std::{
-    fmt::{self, Display, Formatter},
     fs::{self, create_dir_all},
     path::PathBuf,
-    process::Command,
 };
 
 /// Component wrapper for registry-based startup (per-node).
@@ -60,33 +57,6 @@ pub struct Crio {
     process: Process,
     socket: CriSocket,
     node_name: String,
-}
-
-/// Simple CRI socket abstraction
-pub struct CriSocket(PathBuf);
-
-impl Display for CriSocket {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.display())
-    }
-}
-
-/// Maximum usable bytes in a Unix socket path (108 - 1 for null terminator)
-pub const MAX_SOCKET_PATH_LEN: usize = 107;
-
-impl CriSocket {
-    /// Create a new CRI socket, validating the path length against Unix limits.
-    pub fn new(path: PathBuf) -> Result<CriSocket> {
-        if path.display().to_string().len() > MAX_SOCKET_PATH_LEN {
-            bail!("Socket path '{}' is too long", path.display())
-        }
-        Ok(CriSocket(path))
-    }
-
-    /// Format the socket path as a `unix://` URI for CRI clients.
-    pub fn to_socket_string(&self) -> String {
-        format!("unix://{}", self.0.display())
-    }
 }
 
 const CRIO: &str = "crio";
@@ -155,27 +125,7 @@ impl Crio {
                 ),
             )?;
 
-            let cidr = network
-                .crio_cidrs()
-                .get(node as usize)
-                .with_context(|| format!("Unable to find CIDR for {}", node_name))?;
-            fs::write(
-                network_dir.join("10-bridge.json"),
-                to_string_pretty(&json!({
-                    "cniVersion": "0.3.1",
-                    "name": format!("kubernix-{}", node_name),
-                    "type": "bridge",
-                    "bridge": format!("{}.{}", Network::INTERFACE_PREFIX, node),
-                    "isGateway": true,
-                    "ipMasq": true,
-                    "hairpinMode": true,
-                    "ipam": {
-                        "type": "host-local",
-                        "routes": [{ "dst": "0.0.0.0/0" }],
-                        "ranges": [[{ "subnet": cidr }]]
-                    }
-                }))?,
-            )?;
+            cri::write_cni_config(&network_dir, &node_name, node, network)?;
         }
         let config_dir_arg = format!("--config-dir={}", config_dir.display());
         let args: &[&str] = &[&config_dir_arg];
@@ -213,53 +163,13 @@ impl Crio {
             .join(CRIO)
             .join(Node::name(config, network, node))
     }
-
-    /// Remove all containers via crictl invocations
-    fn remove_all_containers(&self) -> Result<()> {
-        debug!("Removing all CRI-O workloads on {}", self.node_name);
-
-        let output = Command::new("crictl")
-            .env(RUNTIME_ENV, self.socket.to_socket_string())
-            .arg("pods")
-            .arg("-q")
-            .output()?;
-        let stdout = String::from_utf8(output.stdout)?;
-        if !output.status.success() {
-            debug!("crictl pods stdout ({}): {}", self.node_name, stdout);
-            debug!(
-                "crictl pods stderr ({}): {}",
-                self.node_name,
-                String::from_utf8(output.stderr)?
-            );
-            bail!("crictl pods command failed ({})", self.node_name);
-        }
-
-        for x in stdout.lines() {
-            debug!("Removing pod {} on {}", x, self.node_name);
-            let output = Command::new("crictl")
-                .env(RUNTIME_ENV, self.socket.to_socket_string())
-                .arg("rmp")
-                .arg("-f")
-                .arg(x)
-                .output()?;
-            if !output.status.success() {
-                debug!("crictl rmp ({}): {:?}", self.node_name, output);
-                bail!("crictl rmp command failed ({})", self.node_name);
-            }
-        }
-
-        debug!("All workloads removed on {}", self.node_name);
-        Ok(())
-    }
 }
 
 impl Stoppable for Crio {
     fn stop(&mut self) -> Result<()> {
-        // Remove all running containers
-        self.remove_all_containers()
-            .with_context(|| format!("Unable to remove CRI-O containers on {}", self.node_name,))?;
+        cri::remove_all_containers("CRI-O", &self.socket, &self.node_name)
+            .with_context(|| format!("Unable to remove CRI-O containers on {}", self.node_name))?;
 
-        // Stop the process, should never really fail
         self.process.stop()
     }
 }
@@ -267,25 +177,6 @@ impl Stoppable for Crio {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn cri_socket_success() -> Result<()> {
-        CriSocket::new("/some/path.sock".into())?;
-        Ok(())
-    }
-
-    #[test]
-    fn cri_socket_failure() {
-        assert!(CriSocket::new("a".repeat(MAX_SOCKET_PATH_LEN + 1).into()).is_err());
-    }
-
-    #[test]
-    fn cri_socket_string_format() -> Result<()> {
-        let socket = CriSocket::new("/run/crio.sock".into())?;
-        assert_eq!(socket.to_socket_string(), "unix:///run/crio.sock");
-        assert_eq!(socket.to_string(), "/run/crio.sock");
-        Ok(())
-    }
 
     #[test]
     fn component_metadata() {

--- a/src/kubelet.rs
+++ b/src/kubelet.rs
@@ -1,13 +1,13 @@
 //! Kubernetes kubelet node agent component.
 //!
 //! Runs `kubelet` on each node, responsible for managing pods and
-//! containers via the CRI-O container runtime.
+//! containers via the configured CRI runtime.
 
 use crate::{
     component::{ClusterContext, Component, Phase},
     config::Config,
     container::Container,
-    crio::{Crio, MAX_SOCKET_PATH_LEN},
+    cri::{self, MAX_SOCKET_PATH_LEN},
     kubeconfig::KubeConfig,
     network::Network,
     node::Node,
@@ -92,7 +92,7 @@ impl Kubelet {
             ca = pki.ca().cert().display(),
             dns = network.dns()?,
             cidr = network
-                .crio_cidrs()
+                .pod_cidrs()
                 .get(node as usize)
                 .context("Unable to retrieve kubelet CIDR")?,
             cert = identity.cert().display(),
@@ -108,7 +108,7 @@ impl Kubelet {
             &format!("--root-dir={}", root_dir.display()),
             &format!(
                 "--container-runtime-endpoint={}",
-                Crio::socket(config, network, node)?.to_socket_string(),
+                cri::cri_socket(config, network, node)?.to_socket_string(),
             ),
             &format!(
                 "--kubeconfig={}",
@@ -151,7 +151,7 @@ stoppable!(Kubelet);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crio::MAX_SOCKET_PATH_LEN;
+    use crate::cri::MAX_SOCKET_PATH_LEN;
 
     #[test]
     fn config_template_renders() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,10 @@ mod apiserver;
 mod component;
 mod config;
 mod container;
+mod containerd;
 mod controllermanager;
 mod coredns;
+mod cri;
 mod crio;
 mod encryptionconfig;
 mod etcd;
@@ -25,7 +27,7 @@ mod proxy;
 mod scheduler;
 mod system;
 
-pub use config::{Config, LogFormat};
+pub use config::{Config, CriRuntime, LogFormat};
 pub use logger::Logger;
 
 /// Write `content` to `path` only if the file does not exist or its
@@ -46,7 +48,7 @@ use crate::nix::Nix;
 use component::{ClusterContext, ComponentRegistry};
 use container::Container;
 use coredns::CoreDns;
-use crio::Crio;
+use cri::RUNTIME_ENV;
 use encryptionconfig::EncryptionConfig;
 use kubeconfig::KubeConfig;
 use kubectl::Kubectl;
@@ -78,8 +80,6 @@ use std::{
     thread::{self, sleep},
     time::{Duration, Instant},
 };
-
-const RUNTIME_ENV: &str = "CONTAINER_RUNTIME_ENDPOINT";
 
 /// The main entry point for the application
 pub struct Kubernix {
@@ -244,7 +244,14 @@ impl Kubernix {
         registry.register(Box::new(controllermanager::ControllerManagerComponent));
         registry.register(Box::new(scheduler::SchedulerComponent));
         for node in 0..config.nodes() {
-            registry.register(Box::new(crio::CrioComponent::new(node)));
+            match config.cri_runtime() {
+                config::CriRuntime::Crio => {
+                    registry.register(Box::new(crio::CrioComponent::new(node)));
+                }
+                config::CriRuntime::Containerd => {
+                    registry.register(Box::new(containerd::ContainerdComponent::new(node)));
+                }
+            }
             registry.register(Box::new(kubelet::KubeletComponent::new(node)));
         }
         registry.register(Box::new(proxy::ProxyComponent));
@@ -330,7 +337,7 @@ impl Kubernix {
             format!(
                 "export {}={}\nexport {}={}",
                 RUNTIME_ENV,
-                Crio::socket(&self.config, &self.network, 0)?.to_socket_string(),
+                cri::cri_socket(&self.config, &self.network, 0)?.to_socket_string(),
                 "KUBECONFIG",
                 self.kubectl.kubeconfig().display(),
             ),

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,8 +1,8 @@
 //! Cluster network topology and CIDR allocation.
 //!
 //! Splits a parent CIDR into non-overlapping subnets for the cluster
-//! network, service network, and per-node CRI-O pod networks. Also
-//! checks for conflicts with existing system routes.
+//! network, service network, and per-node pod networks. Also checks
+//! for conflicts with existing system routes.
 
 use crate::Config;
 use anyhow::{Context, Result, bail};
@@ -18,7 +18,7 @@ use std::{
 #[must_use]
 pub struct Network {
     cluster_cidr: Ipv4Network,
-    crio_cidrs: Vec<Ipv4Network>,
+    pod_cidrs: Vec<Ipv4Network>,
     service_cidr: Ipv4Network,
     etcd_client: SocketAddr,
     etcd_peer: SocketAddr,
@@ -34,9 +34,9 @@ impl Network {
         &self.cluster_cidr
     }
 
-    /// Per-node CRI-O pod network subnets, one per configured node.
-    pub fn crio_cidrs(&self) -> &[Ipv4Network] {
-        &self.crio_cidrs
+    /// Per-node pod network subnets, one per configured node.
+    pub fn pod_cidrs(&self) -> &[Ipv4Network] {
+        &self.pod_cidrs
     }
 
     /// Subnet reserved for Kubernetes Service ClusterIPs.
@@ -61,7 +61,7 @@ impl Network {
 
     /// Calculate the subnet prefix to use for splitting the parent CIDR.
     ///
-    /// We need (2 + nodes) subnets: cluster, service, and one per CRI-O node.
+    /// We need (2 + nodes) subnets: cluster, service, and one per node.
     /// The prefix is chosen so that all subnets fit inside the parent CIDR.
     fn subnet_prefix(parent_prefix: u8, nodes: u8) -> Result<u8> {
         let required = 2 + u32::from(nodes); // cluster + service + N nodes
@@ -98,19 +98,19 @@ impl Network {
         )?;
         debug!("Using service CIDR {}", service_cidr);
 
-        let mut crio_cidrs = vec![];
+        let mut pod_cidrs = vec![];
         let mut offset = cluster_cidr.size() + service_cidr.size();
         for node in 0..config.nodes() {
             let cidr = Ipv4Network::new(
                 config
                     .cidr()
                     .nth(offset)
-                    .context("Unable to retrieve CRI-O CIDR start IP")?,
+                    .context("Unable to retrieve pod CIDR start IP")?,
                 subnet_prefix,
             )?;
             offset += cidr.size();
-            debug!("Using CRI-O ({}) CIDR {}", node, cidr);
-            crio_cidrs.push(cidr);
+            debug!("Using pod ({}) CIDR {}", node, cidr);
+            pod_cidrs.push(cidr);
         }
 
         // Set the rest of the networking related adresses and paths
@@ -124,7 +124,7 @@ impl Network {
 
         Ok(Self {
             cluster_cidr,
-            crio_cidrs,
+            pod_cidrs,
             service_cidr,
             etcd_client,
             etcd_peer,
@@ -208,14 +208,14 @@ pub mod tests {
             "service CIDR should be the second /18 subnet"
         );
         assert_eq!(
-            n.crio_cidrs().len(),
+            n.pod_cidrs().len(),
             1,
-            "single node should have one CRI-O CIDR"
+            "single node should have one pod CIDR"
         );
         assert_eq!(
-            n.crio_cidrs()[0].to_string(),
+            n.pod_cidrs()[0].to_string(),
             "10.10.128.0/18",
-            "CRI-O CIDR should be the third /18 subnet"
+            "pod CIDR should be the third /18 subnet"
         );
         Ok(())
     }


### PR DESCRIPTION
- Introduce `CriRuntime` enum (`crio`, `containerd`) and `--cri-runtime` CLI flag (default: `crio`)
- Extract shared CRI types (`CriSocket`, `MAX_SOCKET_PATH_LEN`, `RUNTIME_ENV`) into `src/cri.rs`
- Add `ContainerdComponent` in `src/containerd.rs` following existing CRI-O patterns
- Rename `crio_cidrs` to `pod_cidrs` in network module (runtime-agnostic)
- Add `containerd` to Nix packages
- Duplicate integration test matrix for both CRI runtimes (single + multi-node)