### PR TITLE
Prepare v0.3.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "kubernix"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubernix"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Sascha Grunert <mail@saschagrunert.de>"]
 edition = "2024"
 rust-version = "1.88"
@@ -9,7 +9,7 @@ categories = ["command-line-utilities"]
 description = "Kubernetes development cluster bootstrapping with Nix packages"
 documentation = "https://docs.rs/kubernix"
 homepage = "https://github.com/saschagrunert/kubernix"
-keywords = ["kubernetes", "nix", "nix-flakes", "crio", "kube"]
+keywords = ["kubernetes", "nix", "nix-flakes", "crio", "containerd"]
 readme = "README.md"
 repository = "https://github.com/saschagrunert/kubernix"
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ components. For example, etcd gets started via:
 
 ```json
 {
-  "command": "/nix/store/…-etcd-3.6.11-bin/bin/etcd",
+  "command": "/nix/store/…-etcd-3.6.13-bin/bin/etcd",
   "args": [
     "--advertise-client-urls=https://127.0.0.1:2379",
     "--client-cert-auth",

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -9,14 +9,14 @@ with pkgs;
   containerd
   cri-o
   cri-tools
+  crun
   etcd
   iproute2
   iptables
   kmod
-  kubernetes
   kubectl
+  kubernetes
   podman
-  crun
   socat
   sysctl
   util-linux

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -37,7 +37,7 @@ impl Display for CriSocket {
 impl CriSocket {
     /// Create a new CRI socket, validating the path length against Unix limits.
     pub fn new(path: PathBuf) -> Result<CriSocket> {
-        if path.display().to_string().len() > MAX_SOCKET_PATH_LEN {
+        if path.as_os_str().len() > MAX_SOCKET_PATH_LEN {
             bail!("Socket path '{}' is too long", path.display())
         }
         Ok(CriSocket(path))

--- a/src/kubelet.rs
+++ b/src/kubelet.rs
@@ -71,9 +71,7 @@ impl Kubelet {
         let dir = config.root().join(KUBELET).join(&node_name);
         let root_dir = dir.join("run");
         // pod-resources/<pid> is the longest socket path kubelet creates
-        if root_dir.display().to_string().len() + "pod-resources/1234567890".len()
-            > MAX_SOCKET_PATH_LEN
-        {
+        if root_dir.as_os_str().len() + "pod-resources/1234567890".len() > MAX_SOCKET_PATH_LEN {
             bail!(
                 "Kubelet run path '{}' is too long for unix sockets",
                 root_dir.display()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod proxy;
 mod scheduler;
 mod system;
 
-pub use config::{Config, CriRuntime, LogFormat};
+pub use config::{Config, CriRuntime, LogFormat, SubCommand};
 pub use logger::Logger;
 
 /// Write `content` to `path` only if the file does not exist or its
@@ -122,8 +122,12 @@ impl Kubernix {
             )
         }
 
-        let shell_cmd = format!(". {} && exec {}", env_file.display(), config.shell_ok()?);
-        Nix::run(&config, &["bash", "-c", &format!("'{}'", shell_cmd)])?;
+        let shell_cmd = format!(
+            ". '{}' && exec '{}'",
+            env_file.display(),
+            config.shell_ok()?
+        );
+        Nix::run(&config, &["bash", "-c", &shell_cmd])?;
 
         info!("Bye, leaving the Kubernix environment");
         Ok(())

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,9 +1,9 @@
 //! Nix environment bootstrapping.
 //!
 //! Manages the `nix develop` shell that provides all runtime
-//! dependencies (etcd, kubernetes, CRI-O, etc.) at pinned versions.
-//! Re-executes the kubernix binary inside the Nix shell, forwarding
-//! all CLI options.
+//! dependencies (etcd, kubernetes, CRI runtimes, etc.) at pinned
+//! versions. Re-executes the kubernix binary inside the Nix shell,
+//! forwarding all CLI options.
 
 use crate::{Config, system::System};
 use anyhow::{Result, bail};
@@ -38,6 +38,17 @@ impl Nix {
             )?;
             fs::write(dir.join("flake.lock"), include_str!("../flake.lock"))?;
 
+            for pkg in config.packages() {
+                if !pkg
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
+                {
+                    bail!(
+                        "Invalid package name '{}': only alphanumeric characters, dashes, underscores, and dots are allowed",
+                        pkg,
+                    );
+                }
+            }
             let packages = &config.packages().join(" ");
             debug!("Adding additional packages: {:?}", config.packages());
             fs::write(
@@ -75,6 +86,7 @@ impl Nix {
         let cidr = format!("{}", config.cidr());
         let nodes = format!("{}", config.nodes());
         let container_runtime = config.container_runtime();
+        let cri_runtime = format!("{}", config.cri_runtime());
 
         let shell_val: String = config.shell().unwrap_or_default().to_owned();
         let overlay_val = config.overlay().map(|o| format!("{}", o.display()));
@@ -92,6 +104,8 @@ impl Nix {
             nodes.as_str(),
             "--container-runtime",
             container_runtime,
+            "--cri-runtime",
+            cri_runtime.as_str(),
         ];
 
         if let Some(ref overlay) = overlay_val {
@@ -125,23 +139,26 @@ impl Nix {
         Self::run(&config, &args)
     }
 
-    /// Run a command inside the nix develop shell
+    /// Run a command inside the nix develop shell.
+    ///
+    /// Each element in `args` is passed as a separate OS argument to
+    /// `nix develop --command`, avoiding shell interpretation.
     pub fn run(config: &Config, args: &[&str]) -> Result<()> {
         let nix_dir = config.root().join(Self::DIR);
         let flake_ref = format!("path:{}", nix_dir.display());
 
-        let status = Command::new(System::find_executable("nix")?)
-            .env(Nix::NIX_ENV, "true")
+        let mut cmd = Command::new(System::find_executable("nix")?);
+        cmd.env(Nix::NIX_ENV, "true")
             .arg("develop")
             .arg(&flake_ref)
             .arg("--no-update-lock-file")
             .arg("--log-format")
             .arg("raw")
-            .arg("--command")
-            .arg("bash")
-            .arg("-c")
-            .arg(args.join(" "))
-            .status()?;
+            .arg("--command");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        let status = cmd.status()?;
         if !status.success() {
             bail!("nix develop exited with status {}", status);
         }


### PR DESCRIPTION
- Bump version to 0.3.4, add "containerd" keyword
- Fix shell injection in `Nix::run()`: pass args as separate OS arguments
  to `nix develop --command` instead of joining with spaces for `bash -c`
- Remove redundant single-quote wrapping in `new_shell()`
- Forward `--cri-runtime` in bootstrap re-exec (was missing unlike all
  other flags)
- Validate `--packages` names against `[a-zA-Z0-9._-]` before Nix
  expression interpolation
- Fix socket path length check to use `as_os_str().len()` instead of
  `display().to_string().len()` for correct byte measurement
- Re-export `SubCommand` from the crate root
- Fix stale etcd version in README example (3.6.11 to 3.6.13)
- Sort `nix/packages.nix` alphabetically