### PR TITLE
Add rootless (user namespace) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-integration:
-    name: test / integration / ${{ matrix.cri_runtime }} / ${{ matrix.mode }}
+    name: test / integration / ${{ matrix.cri_runtime }} / ${{ matrix.mode }}${{ matrix.rootless && ' / rootless' || '' }}
     runs-on: ubuntu-latest
     needs: build-cross
     strategy:
@@ -261,15 +261,35 @@ jobs:
           - mode: single
             nodes: 1
             cri_runtime: crio
+            rootless: false
           - mode: multi
             nodes: 2
             cri_runtime: crio
+            rootless: false
           - mode: single
             nodes: 1
             cri_runtime: containerd
+            rootless: false
           - mode: multi
             nodes: 2
             cri_runtime: containerd
+            rootless: false
+          - mode: single
+            nodes: 1
+            cri_runtime: crio
+            rootless: true
+          - mode: single
+            nodes: 1
+            cri_runtime: containerd
+            rootless: true
+          - mode: multi
+            nodes: 2
+            cri_runtime: crio
+            rootless: true
+          - mode: multi
+            nodes: 2
+            cri_runtime: containerd
+            rootless: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
@@ -281,16 +301,25 @@ jobs:
           name: kubernix-x86_64
       - run: chmod +x kubernix
       - name: Set hostname
+        if: ${{ !matrix.rootless }}
         run: |
           echo "127.0.0.1 test" | sudo tee -a /etc/hosts
           sudo hostnamectl set-hostname test
       - name: Prepare the system
+        if: ${{ !matrix.rootless }}
         run: sudo contrib/prepare-system
-      - name: Run ${{ matrix.cri_runtime }} / ${{ matrix.mode }} integration test
+      - name: Prepare rootless environment
+        if: ${{ matrix.rootless }}
         run: |
-          sudo -E env "PATH=$PATH" ./kubernix --log-level=debug --no-shell --addons --nodes=${{ matrix.nodes }} --cri-runtime=${{ matrix.cri_runtime }} &
+          sudo sh -c 'echo "kernel.unprivileged_userns_clone=1" > /etc/sysctl.d/rootless.conf && sysctl --system'
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          sudo sh -c 'mkdir -p /etc/systemd/system/user-.slice.d && printf "[Slice]\nDelegate=yes\n" > /etc/systemd/system/user-.slice.d/delegate.conf && systemctl daemon-reload'
+      - name: Run integration test
+        run: |
+          # --addons with no value disables addon deployment (empty list)
+          ${{ !matrix.rootless && 'sudo -E env "PATH=$PATH"' || '' }} ./kubernix --log-level=debug --no-shell --addons --nodes=${{ matrix.nodes }} --cri-runtime=${{ matrix.cri_runtime }} &
           KUBERNIX_PID=$!
-          timeout 300 bash -c 'while [ ! -f kubernix-run/kubernix.pid ]; do sleep 1; done'
+          timeout 600 bash -c 'while [ ! -f kubernix-run/kubernix.pid ]; do sleep 1; done'
           echo "Cluster is up, running checks"
           export KUBECONFIG=$PWD/kubernix-run/kubeconfig/admin.kubeconfig
 
@@ -310,6 +339,6 @@ jobs:
           fi
 
           echo "All assertions passed"
-          sudo kill $KUBERNIX_PID
+          ${{ !matrix.rootless && 'sudo' || '' }} kill $KUBERNIX_PID
           wait $KUBERNIX_PID || true
-        timeout-minutes: 10
+        timeout-minutes: 15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "kubernix"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubernix"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Sascha Grunert <mail@saschagrunert.de>"]
 edition = "2024"
 rust-version = "1.88"

--- a/README.md
+++ b/README.md
@@ -46,18 +46,19 @@ The following technology stack is currently being used:
 | cni-plugins     | v1.9.1   |
 | conmon          | v2.2.1   |
 | conntrack-tools | v1.4.8   |
-| containerd      | v2.3.1   |
-| cri-o-wrapper   | v1.36.2  |
+| containerd      | v2.3.3   |
+| cri-o-wrapper   | v1.36.3  |
 | cri-tools       | v1.36.0  |
 | crun            | v1.27.1  |
-| etcd            | v3.6.13  |
+| etcd            | v3.6.14  |
 | iproute2        | v7.1.0   |
 | iptables        | v1.8.13  |
 | kmod            | v31      |
-| kubectl         | v1.36.2  |
-| kubernetes      | v1.36.2  |
-| nss-cacert      | v3.125   |
+| kubectl         | v1.36.3  |
+| kubernetes      | v1.36.3  |
+| nss-cacert      | v3.126   |
 | podman          | v5.8.4   |
+| rootlesskit     | v2.3.6   |
 | socat           | v1.8.1.3 |
 | sysctl          | v4.0.6   |
 | util-linux      | v2.42.2  |
@@ -79,7 +80,7 @@ graph TD
 
     A --- etcd
     B --- apiserver
-    C --- scheduler & controller-manager & cri["cri-o or containerd (x N)"] & proxy
+    C --- scheduler & controller-manager & cri["cri-o or containerd (x N)"] & proxy["proxy (root only)"]
     D --- kubelet["kubelet (x N)"]
 ```
 
@@ -115,16 +116,31 @@ $ make build-release
 The binary should now be available in the `target/release/kubernix` directory of
 the project. Alternatively, install the application via `cargo install kubernix`.
 
-After the successful binary retrieval, start KuberNix by running it as `root`:
+After the successful binary retrieval, start KuberNix:
 
 ```
-$ sudo kubernix
+$ kubernix
 ```
 
 KuberNix will now take care that the Nix environment gets correctly setup,
 downloads the needed binaries and starts the cluster. Per default it will create
 a directory called `kubernix-run` in the current path which contains all necessary
 data for the cluster.
+
+When running as a non-root user, KuberNix uses `rootlesskit` to provide a user
+namespace where all components run as fake root. This requires unprivileged user
+namespaces (`kernel.unprivileged_userns_clone=1`) and cgroup v2 with user
+delegation. On Ubuntu 23.10+, you may also need to set
+`kernel.apparmor_restrict_unprivileged_userns=0`. Kube-proxy is skipped without
+root (it needs iptables access), so ClusterIP-based Service routing is not
+available. Pod egress to external networks also requires masquerading, which
+is not possible without iptables. Pod-to-pod communication within the
+cluster works normally.
+
+In multi-node rootless mode, all nodes run as direct processes (no container
+isolation) with `--hostname-override` for node identity. Running with `sudo`
+gives full functionality including kube-proxy and container-based multi-node
+isolation.
 
 #### Shell Environment
 
@@ -182,11 +198,11 @@ proxy/kube-proxy.log
 scheduler/kube-scheduler.log
 ```
 
-If you want to spawn an additional shell session, simply run `kubernix shell` in
-the same directory as where the initial bootstrap happened.
+If you want to spawn an additional shell session, simply run `kubernix shell`
+in the same directory as where the initial bootstrap happened.
 
 ```
-$ sudo kubernix shell
+$ kubernix shell
 [INFO ] Spawning new kubernix shell in: 'kubernix-run'
 > kubectl run alpine --image=alpine -it --rm -- sh
 If you don't see a command prompt, try pressing enter.
@@ -289,7 +305,7 @@ self: super: {
 Now we can run KuberNix with the `--overlay, -o` command line argument:
 
 ```
-$ sudo kubernix --overlay overlay.nix
+$ kubernix --overlay overlay.nix
 [INFO ] Nix environment not found, bootstrapping one
 [INFO ] Using custom overlay 'overlay.nix'
 these derivations will be built:
@@ -308,7 +324,7 @@ can easily utilize additional tools in a reproducible way. For example, when to
 comes to using always the same [Helm][20] version, you could simply run:
 
 ```
-$ sudo kubernix -p kubernetes-helm
+$ kubernix -p kubernetes-helm
 [INFO ] Nix environment not found, bootstrapping one
 [INFO ] Bootstrapping cluster inside nix environment
 …

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784555310,
-        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
+        "lastModified": 1786534138,
+        "narHash": "sha256-fBJMdnKUTUDtfi/BYLr71HLaC9dG382arxLF2Egg2uo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
+        "rev": "044bfe75bfe4c7bbe043dc17b5e42ea823b84a09",
         "type": "github"
       },
       "original": {

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -17,6 +17,7 @@ with pkgs;
   kubectl
   kubernetes
   podman
+  rootlesskit
   socat
   sysctl
   util-linux

--- a/src/assets/containerd.toml
+++ b/src/assets/containerd.toml
@@ -7,6 +7,7 @@ address = "{socket}"
 
 [plugins."io.containerd.cri.v1.images"]
 sandbox_image = "registry.k8s.io/pause:3.10"
+snapshotter = "{snapshotter}"
 
 [plugins."io.containerd.cri.v1.runtime"]
 enable_unprivileged_ports = true
@@ -25,3 +26,6 @@ runtime_type = "io.containerd.runc.v2"
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.crun.options]
 BinaryName = "{runtime_path}"
 SystemdCgroup = false
+
+[plugins."io.containerd.nri.v1.nri"]
+disable = {disable_nri}

--- a/src/assets/crio.conf
+++ b/src/assets/crio.conf
@@ -28,8 +28,7 @@ storage_driver = "{storage_driver}"
 
 # List to pass options to the storage driver. Please refer to
 # containers-storage.conf(5) to see all available storage options.
-#storage_option = [
-#]
+storage_option = [{storage_option}]
 
 # The default log directory where all logs will go unless directly specified by
 # the kubelet. The log directory specified must be an absolute directory.
@@ -77,6 +76,9 @@ grpc_max_recv_msg_size = 16777216
 # The crio.runtime table contains settings pertaining to the OCI runtime used
 # and options for how to set up and manage the OCI runtime.
 [crio.runtime]
+
+# Disable hostport mapping in rootless mode (no iptables/nftables access).
+disable_hostport_mapping = {disable_hostport_mapping}
 
 # A list of ulimits to be set in containers by default, specified as
 # "<ulimit name>=<soft limit>:<hard limit>", for example:
@@ -196,7 +198,7 @@ log_to_journald = false
 container_exits_dir = "{exits_dir}"
 
 # Path to directory for container attach sockets.
-container_attach_socket_dir = "/var/run/crio"
+container_attach_socket_dir = "{attach_socket_dir}"
 
 # The prefix to use for the source of the bind mounts.
 bind_mount_prefix = ""
@@ -237,7 +239,7 @@ manage_ns_lifecycle = false
 
 # The directory where the state of the managed namespaces gets tracked.
 # Only used when manage_ns_lifecycle is true.
-namespaces_dir = "/var/run"
+namespaces_dir = "{namespaces_dir}"
 
 # pinns_path is the path to find the pinns binary, which is needed to manage namespace lifecycle
 pinns_path = ""
@@ -360,3 +362,7 @@ enable_metrics = false
 
 # The port on which the metrics server will listen.
 metrics_port = 9090
+
+# NRI (Node Resource Interface) configuration.
+[crio.nri]
+enable_nri = {enable_nri}

--- a/src/assets/kubelet-rootless.yml
+++ b/src/assets/kubelet-rootless.yml
@@ -1,0 +1,27 @@
+---
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    enabled: true
+  x509:
+    clientCAFile: "{ca}"
+authorization:
+  mode: Webhook
+clusterDomain: "cluster.local"
+clusterDNS:
+  - "{dns}"
+podCIDR: "{cidr}"
+runtimeRequestTimeout: "15m"
+tlsCertFile: "{cert}"
+tlsPrivateKeyFile: "{key}"
+cgroupDriver: "none"
+cgroupsPerQOS: false
+failSwapOn: false
+enforceNodeAllocatable: []
+port: {port}
+healthzPort: {healthzPort}
+featureGates:
+  KubeletInUserNamespace: true

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,6 +201,10 @@ pub struct Config {
     /// The CRI runtime to use (crio or containerd)
     cri_runtime: CriRuntime,
 
+    #[serde(skip)]
+    #[arg(skip)]
+    rootless: bool,
+
     #[arg(
         default_value = "coredns",
         env = "KUBERNIX_ADDONS",
@@ -282,6 +286,16 @@ impl Config {
     /// Cluster addons to deploy after bootstrap (e.g. `coredns`).
     pub fn addons(&self) -> &[String] {
         &self.addons
+    }
+
+    /// Whether the cluster is running in rootless (user namespace) mode.
+    pub fn is_rootless(&self) -> bool {
+        self.rootless
+    }
+
+    /// Set rootless mode (auto-detected from UID at startup).
+    pub fn set_rootless(&mut self, val: bool) {
+        self.rootless = val;
     }
 }
 
@@ -378,6 +392,12 @@ pub mod tests {
         }
         c.root = tempdir()?.keep();
         c.canonicalize_root()?;
+        Ok(c)
+    }
+
+    pub fn test_config_rootless() -> Result<Config> {
+        let mut c = test_config()?;
+        c.set_rootless(true);
         Ok(c)
     }
 
@@ -522,6 +542,29 @@ root = "root"
         };
         fs::write(c.root.join(Config::FILENAME), "invalid")?;
         assert!(c.try_load_file().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn rootless_default_false() -> Result<()> {
+        let c = test_config()?;
+        assert!(!c.is_rootless());
+        Ok(())
+    }
+
+    #[test]
+    fn rootless_set_and_get() -> Result<()> {
+        let c = test_config_rootless()?;
+        assert!(c.is_rootless());
+        Ok(())
+    }
+
+    #[test]
+    fn rootless_not_serialized() -> Result<()> {
+        let mut c = test_config()?;
+        c.set_rootless(true);
+        let toml = toml::to_string(&c).unwrap();
+        assert!(!toml.contains("rootless"));
         Ok(())
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -30,8 +30,8 @@ impl Container {
         let policy_json = Self::policy_json(config);
         fs::write(&policy_json, include_str!("assets/policy.json"))?;
 
-        // Nothing needs to be done on single node runs or root users
-        if !config.multi_node() {
+        // Nothing needs to be done on single node or rootless runs
+        if !config.multi_node() || config.is_rootless() {
             return Ok(());
         }
 
@@ -142,10 +142,10 @@ impl Container {
             args_vec.extend(podman_args.iter().map(|x| x.as_str()).collect::<Vec<_>>())
         }
 
-        // Mount /dev/mapper if available
+        // Mount /dev/mapper if available (requires privileges)
         let dev_mapper = PathBuf::from("/").join("dev").join("mapper");
         let arg_volume_dev_mapper = &Self::volume_arg(dev_mapper.display());
-        if dev_mapper.exists() {
+        if !config.is_rootless() && dev_mapper.exists() {
             args_vec.push(arg_volume_dev_mapper);
         }
 

--- a/src/containerd.rs
+++ b/src/containerd.rs
@@ -67,7 +67,7 @@ impl Containerd {
 
         let crun_path: String;
         let plugin_dir: String;
-        if config.multi_node() {
+        if config.multi_node() && !config.is_rootless() {
             // Use bare binary name so the runc v2 shim resolves crun from $PATH
             // inside the container (nix-shell provides it).
             crun_path = "crun".to_string();
@@ -92,6 +92,12 @@ impl Containerd {
             create_dir_all(&dir)?;
             create_dir_all(&cni_conf_dir)?;
 
+            let snapshotter =
+                if config.multi_node() || config.is_rootless() || System::in_container()? {
+                    "native"
+                } else {
+                    "overlayfs"
+                };
             fs::write(
                 &config_file,
                 format!(
@@ -102,16 +108,18 @@ impl Containerd {
                     plugin_dir = plugin_dir,
                     cni_conf_dir = cni_conf_dir.display(),
                     runtime_path = crun_path,
+                    snapshotter = snapshotter,
+                    disable_nri = config.is_rootless(),
                 ),
             )?;
 
-            cri::write_cni_config(&cni_conf_dir, &node_name, node, network)?;
+            cri::write_pod_network_config(config, &cni_conf_dir, &node_name, node, network)?;
         }
 
         let config_arg = format!("--config={}", config_file.display());
         let args: &[&str] = &[&config_arg];
 
-        let mut process = if config.multi_node() {
+        let mut process = if config.multi_node() && !config.is_rootless() {
             // containerd has no --cni-plugin-dir CLI flag (unlike CRI-O), so
             // patch bin_dirs in the config before starting the daemon. The
             // container entrypoint runs all args through `bash -c "$*"`, so

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -57,8 +57,24 @@ pub fn cri_socket(config: &Config, network: &Network, node: u8) -> Result<CriSoc
     }
 }
 
-/// Write the CNI bridge network configuration for a node.
-pub fn write_cni_config(
+/// Write CNI network configuration for a node, selecting the appropriate
+/// plugin based on whether rootless mode is active.
+pub fn write_pod_network_config(
+    config: &Config,
+    cni_conf_dir: &Path,
+    node_name: &str,
+    node: u8,
+    network: &Network,
+) -> Result<()> {
+    if config.is_rootless() {
+        write_rootless_cni_config(cni_conf_dir, node_name, node, network)
+    } else {
+        write_cni_config(cni_conf_dir, node_name, node, network)
+    }
+}
+
+/// Write the CNI bridge network configuration for a node (root mode).
+fn write_cni_config(
     cni_conf_dir: &Path,
     node_name: &str,
     node: u8,
@@ -78,6 +94,33 @@ pub fn write_cni_config(
             "isGateway": true,
             "ipMasq": true,
             "hairpinMode": true,
+            "ipam": {
+                "type": "host-local",
+                "routes": [{ "dst": "0.0.0.0/0" }],
+                "ranges": [[{ "subnet": cidr }]]
+            }
+        }))?,
+    )?;
+    Ok(())
+}
+
+/// Write a rootless-compatible CNI config using the ptp plugin.
+fn write_rootless_cni_config(
+    cni_conf_dir: &Path,
+    node_name: &str,
+    node: u8,
+    network: &Network,
+) -> Result<()> {
+    let cidr = network
+        .pod_cidrs()
+        .get(node as usize)
+        .with_context(|| format!("Unable to find CIDR for {}", node_name))?;
+    fs::write(
+        cni_conf_dir.join("10-ptp.json"),
+        to_string_pretty(&json!({
+            "cniVersion": "0.3.1",
+            "name": format!("kubernix-{}", node_name),
+            "type": "ptp",
             "ipam": {
                 "type": "host-local",
                 "routes": [{ "dst": "0.0.0.0/0" }],
@@ -146,6 +189,30 @@ mod tests {
         let socket = CriSocket::new("/run/crio.sock".into())?;
         assert_eq!(socket.to_socket_string(), "unix:///run/crio.sock");
         assert_eq!(socket.to_string(), "/run/crio.sock");
+        Ok(())
+    }
+
+    #[test]
+    fn rootless_cni_config_uses_ptp() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let network = crate::network::Network::new(&crate::config::tests::test_config()?)?;
+        write_rootless_cni_config(dir.path(), "node-0", 0, &network)?;
+        let content = std::fs::read_to_string(dir.path().join("10-ptp.json"))?;
+        let v: serde_json::Value = serde_json::from_str(&content)?;
+        assert_eq!(v["type"], "ptp");
+        assert_eq!(v["ipam"]["type"], "host-local");
+        Ok(())
+    }
+
+    #[test]
+    fn bridge_cni_config_uses_bridge() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let network = crate::network::Network::new(&crate::config::tests::test_config()?)?;
+        write_cni_config(dir.path(), "node-0", 0, &network)?;
+        let content = std::fs::read_to_string(dir.path().join("10-bridge.json"))?;
+        let v: serde_json::Value = serde_json::from_str(&content)?;
+        assert_eq!(v["type"], "bridge");
+        assert_eq!(v["isGateway"], true);
         Ok(())
     }
 }

--- a/src/crio.rs
+++ b/src/crio.rs
@@ -72,7 +72,7 @@ impl Crio {
         let conmon: String;
         let crun_path: String;
         let plugin_dir: String;
-        if config.multi_node() {
+        if config.multi_node() && !config.is_rootless() {
             // Empty paths let CRI-O resolve conmon/crun from $PATH inside the container.
             conmon = String::new();
             crun_path = String::new();
@@ -100,37 +100,48 @@ impl Crio {
             create_dir_all(&network_dir)?;
             create_dir_all(&config_dir)?;
 
+            let attach_dir = dir.join("attach");
+            let ns_dir = dir.join("ns");
+            create_dir_all(&attach_dir)?;
+            create_dir_all(&ns_dir)?;
+
             let containers_dir = dir.join("containers");
             fs::write(
                 &config_file,
                 format!(
                     include_str!("assets/crio.conf"),
+                    attach_socket_dir = attach_dir.display(),
                     conmon = conmon,
                     containers_root = containers_dir.join("storage").display(),
                     containers_runroot = containers_dir.join("run").display(),
                     listen = socket,
                     log_dir = dir.join("log").display(),
+                    namespaces_dir = ns_dir.display(),
                     network_dir = network_dir.display(),
                     plugin_dir = plugin_dir,
                     exits_dir = dir.join("exits").display(),
                     runtime_path = crun_path,
                     runtime_root = dir.join("crun").display(),
                     signature_policy = Container::policy_json(config).display(),
-                    storage_driver = if config.multi_node() || System::in_container()? {
-                        "vfs"
-                    } else {
-                        "overlay"
-                    },
+                    storage_driver =
+                        if config.multi_node() || config.is_rootless() || System::in_container()? {
+                            "vfs"
+                        } else {
+                            "overlay"
+                        },
+                    storage_option = "",
                     version_file = dir.join("version").display(),
+                    disable_hostport_mapping = config.is_rootless(),
+                    enable_nri = !config.is_rootless(),
                 ),
             )?;
 
-            cri::write_cni_config(&network_dir, &node_name, node, network)?;
+            cri::write_pod_network_config(config, &network_dir, &node_name, node, network)?;
         }
         let config_dir_arg = format!("--config-dir={}", config_dir.display());
         let args: &[&str] = &[&config_dir_arg];
 
-        let mut process = if config.multi_node() {
+        let mut process = if config.multi_node() && !config.is_rootless() {
             // Run inside a container, resolve CNI plugin dir from $PATH at runtime
             let identifier = format!("CRI-O {}", node_name);
             let plugin_dir_arg =
@@ -139,7 +150,6 @@ impl Crio {
             let container_args: &[&str] = &[&config_dir_arg, &plugin_dir_arg];
             Container::start(config, &dir, &identifier, CRIO, &node_name, container_args)?
         } else {
-            // Run as usual process
             Process::start(&dir, "CRI-O", CRIO, args)?
         };
         process.wait_ready("No systemd watchdog enabled")?;

--- a/src/kubelet.rs
+++ b/src/kubelet.rs
@@ -85,19 +85,39 @@ impl Kubelet {
             .get(node as usize)
             .with_context(|| format!("Unable to retrieve kubelet identity for {}", node_name))?;
 
-        let yml = format!(
-            include_str!("assets/kubelet.yml"),
-            ca = pki.ca().cert().display(),
-            dns = network.dns()?,
-            cidr = network
-                .pod_cidrs()
-                .get(node as usize)
-                .context("Unable to retrieve kubelet CIDR")?,
-            cert = identity.cert().display(),
-            key = identity.key().display(),
-            port = KUBELET_PORT_BASE + u16::from(node),
-            healthzPort = HEALTHZ_PORT_BASE + u16::from(node),
-        );
+        let ca = pki.ca().cert().display().to_string();
+        let dns = network.dns()?;
+        let cidr = network
+            .pod_cidrs()
+            .get(node as usize)
+            .context("Unable to retrieve kubelet CIDR")?;
+        let cert = identity.cert().display().to_string();
+        let key = identity.key().display().to_string();
+        let port = KUBELET_PORT_BASE + u16::from(node);
+        let healthz_port = HEALTHZ_PORT_BASE + u16::from(node);
+        let yml = if config.is_rootless() {
+            format!(
+                include_str!("assets/kubelet-rootless.yml"),
+                ca = ca,
+                dns = dns,
+                cidr = cidr,
+                cert = cert,
+                key = key,
+                port = port,
+                healthzPort = healthz_port,
+            )
+        } else {
+            format!(
+                include_str!("assets/kubelet.yml"),
+                ca = ca,
+                dns = dns,
+                cidr = cidr,
+                cert = cert,
+                key = key,
+                port = port,
+                healthzPort = healthz_port,
+            )
+        };
         let cfg = dir.join("config.yml");
         write_if_changed(&cfg, &yml)?;
 
@@ -122,7 +142,7 @@ impl Kubelet {
             "--v=2",
         ];
 
-        let mut process = if config.multi_node() {
+        let mut process = if config.multi_node() && !config.is_rootless() {
             // Run inside a container
             let arg_hostname = &format!("--hostname-override={}", node_name);
             let mut modargs: Vec<&str> = vec![arg_hostname];
@@ -135,8 +155,14 @@ impl Kubelet {
                 &node_name,
                 &modargs,
             )?
+        } else if config.multi_node() {
+            // Rootless multi-node: direct process with hostname override
+            let arg_hostname = format!("--hostname-override={}", node_name);
+            let mut modargs: Vec<&str> = vec![&arg_hostname];
+            modargs.extend(args);
+            Process::start(&dir, "Kubelet", KUBELET, &modargs)?
         } else {
-            // Run as usual process
+            // Single-node: run as usual process
             Process::start(&dir, "Kubelet", KUBELET, args)?
         };
         process.wait_ready("Successfully registered node")?;
@@ -191,5 +217,22 @@ mod tests {
     fn component_name_per_node() {
         assert_eq!(KubeletComponent::new(0).name(), "Kubelet (node 0)");
         assert_eq!(KubeletComponent::new(3).name(), "Kubelet (node 3)");
+    }
+
+    #[test]
+    fn rootless_config_template_renders() {
+        let yml = format!(
+            include_str!("assets/kubelet-rootless.yml"),
+            ca = "/tmp/ca.pem",
+            dns = "10.10.64.2",
+            cidr = "10.10.128.0/18",
+            cert = "/tmp/kubelet.pem",
+            key = "/tmp/kubelet-key.pem",
+            port = KUBELET_PORT_BASE,
+            healthzPort = HEALTHZ_PORT_BASE,
+        );
+        assert!(yml.contains("kind: KubeletConfiguration"));
+        assert!(yml.contains("cgroupDriver: \"none\""));
+        assert!(yml.contains("KubeletInUserNamespace: true"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ use process::Stoppables;
 use progress::Progress;
 use system::System;
 
+const ROOTLESS_ENV: &str = "KUBERNIX_ROOTLESS";
+
 use ::nix::{
     mount::{MntFlags, umount2},
     unistd::getuid,
@@ -99,15 +101,25 @@ impl Kubernix {
 
         // Bootstrap if we're not inside a nix shell
         if Nix::is_active() {
+            if config.is_rootless() && std::env::var(ROOTLESS_ENV).as_deref() != Ok("1") {
+                return Self::reexec_rootless();
+            }
             Self::bootstrap_cluster(config)
         } else {
             Nix::bootstrap(config)
         }
     }
 
-    /// Spawn a new shell into the provided configuration environment
+    /// Spawn a new shell into the provided configuration environment.
     pub fn new_shell(mut config: Config) -> Result<()> {
         Self::prepare_env(&mut config)?;
+
+        if config.is_rootless() && std::env::var(ROOTLESS_ENV).as_deref() != Ok("1") {
+            bail!(
+                "The cluster was started in rootless mode. \
+                 Run 'kubernix shell' from within the rootlesskit session."
+            )
+        }
 
         info!(
             "Spawning new kubernix shell in: '{}'",
@@ -135,10 +147,17 @@ impl Kubernix {
 
     /// Prepare the environment based on the provided config
     fn prepare_env(config: &mut Config) -> Result<()> {
-        // Rootless is currently not supported
-        if !getuid().is_root() {
-            bail!("Please run kubernix as root")
-        }
+        let env_rootless = std::env::var(ROOTLESS_ENV).as_deref() == Ok("1");
+        let rootless = if !getuid().is_root() {
+            true
+        } else if env_rootless {
+            // KUBERNIX_ROOTLESS=1 is set by reexec_rootless() inside rootlesskit.
+            // Only honor it when actually inside a user namespace to prevent
+            // a broken cluster from `sudo KUBERNIX_ROOTLESS=1 kubernix`.
+            System::in_user_namespace()
+        } else {
+            false
+        };
 
         // Prepare the configuration
         if config.root().exists() {
@@ -148,9 +167,67 @@ impl Kubernix {
         }
         config.canonicalize_root()?;
 
+        // Set rootless after config loading since try_load_file
+        // replaces the whole struct (resetting #[serde(skip)] fields).
+        config.set_rootless(rootless);
+
         // Setup the logger
         set_boxed_logger(Logger::new(config.log_level(), config.log_format()))
-            .context("Unable to set logger")
+            .context("Unable to set logger")?;
+
+        if config.is_rootless() && !Nix::is_active() {
+            info!("Running in rootless mode");
+        }
+
+        Ok(())
+    }
+
+    /// POSIX single-quote escaping: wraps in single quotes and escapes
+    /// any embedded single quotes with the '\'' sequence.
+    fn shell_escape(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+
+    /// Re-exec kubernix inside rootlesskit for rootless operation.
+    /// All child processes inherit the user namespace.
+    fn reexec_rootless() -> Result<()> {
+        info!("Re-executing inside rootlesskit");
+
+        let exe = std::env::current_exe().context("Unable to determine current executable")?;
+        let args: Vec<String> = std::env::args().skip(1).collect();
+
+        let inner_cmd = format!(
+            "exec {} {}",
+            Self::shell_escape(&exe.display().to_string()),
+            args.iter()
+                .map(|a| Self::shell_escape(a))
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+
+        let mut cmd = Command::new("rootlesskit");
+        cmd.args([
+            "--net=host",
+            "--copy-up=/etc",
+            "--copy-up=/run",
+            "--copy-up=/var/cache",
+            "--copy-up=/var/lib",
+            "--copy-up=/var/log",
+            "--copy-up=/var/run",
+            "bash",
+            "-c",
+            &inner_cmd,
+        ]);
+        cmd.env(ROOTLESS_ENV, "1");
+
+        let status = cmd.status().context(
+            "Failed to start rootlesskit. Is it installed? \
+             (rootless mode requires rootlesskit)",
+        )?;
+
+        // No Kubernix struct or other Drop-bearing resources exist yet,
+        // only the logger from prepare_env.
+        std::process::exit(status.code().unwrap_or(1));
     }
 
     /// Stop kubernix by cleaning up all running processes
@@ -164,14 +241,15 @@ impl Kubernix {
 
     /// The amount of processes to be run
     fn processes(config: &Config) -> u64 {
-        5 + 2 * u64::from(config.nodes())
+        let base = 4 + 2 * u64::from(config.nodes());
+        if config.is_rootless() { base } else { base + 1 }
     }
 
     /// Bootstrap the whole cluster, which assumes to be inside a nix shell
     fn bootstrap_cluster(config: Config) -> Result<()> {
         // Setup the progress bar
         const BASE_STEPS: u64 = 15;
-        let steps = if config.multi_node() {
+        let steps = if config.multi_node() && !config.is_rootless() {
             u64::from(config.nodes()) * 2 + BASE_STEPS
         } else {
             BASE_STEPS
@@ -258,7 +336,9 @@ impl Kubernix {
             }
             registry.register(Box::new(kubelet::KubeletComponent::new(node)));
         }
-        registry.register(Box::new(proxy::ProxyComponent));
+        if !config.is_rootless() {
+            registry.register(Box::new(proxy::ProxyComponent));
+        }
         registry
     }
 
@@ -356,6 +436,10 @@ impl Kubernix {
 
     /// Remove all stale mounts
     fn umount(&self) {
+        if self.config.is_rootless() {
+            debug!("Skipping mount cleanup in rootless mode");
+            return;
+        }
         debug!("Removing active mounts");
         let now = Instant::now();
         while now.elapsed().as_secs() < 15 {

--- a/src/podman.rs
+++ b/src/podman.rs
@@ -81,6 +81,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires conmon in $PATH"]
     fn build_args_success() -> Result<()> {
         let c = test_config()?;
         let p = PathBuf::from("policy.json");
@@ -97,6 +98,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires conmon in $PATH"]
     fn default_args_success() -> Result<()> {
         let c = test_config()?;
         assert!(!Podman::default_args(&c)?.is_empty());

--- a/src/system.rs
+++ b/src/system.rs
@@ -23,9 +23,67 @@ pub struct System {
 impl System {
     /// Create a new system
     pub fn setup(config: &Config) -> Result<Self> {
-        if Self::in_container()? {
-            info!("Skipping modprobe and sysctl for sake of containerization")
-        } else {
+        if config.is_rootless() {
+            let in_userns = Self::in_user_namespace();
+            if !in_userns {
+                warn!(
+                    "Rootless mode but not inside a user namespace, \
+                     skipping directory setup"
+                );
+            } else {
+                // Inside rootlesskit, pre-existing host directories under the
+                // copy-up overlay retain host root ownership (mapped to nobody
+                // in the user namespace) and are not writable. Recreate paths
+                // that kubernix components write to under rootlesskit copy-ups.
+                // When adding a new component that writes to a host path under
+                // /var or /run, add the path here too.
+                for dir in &[
+                    "/var/lib/kubelet",
+                    "/var/lib/crio",
+                    "/var/lib/containers",
+                    "/var/cache/containers",
+                    "/var/log/pods",
+                    "/var/log/containers",
+                    "/var/log/crio",
+                    "/run/lock",
+                    "/run/containers",
+                ] {
+                    let path = PathBuf::from(dir);
+                    if path.exists()
+                        && let Err(e) = fs::remove_dir_all(&path)
+                    {
+                        warn!("Unable to remove '{}': {}", dir, e);
+                    }
+                    fs::create_dir_all(&path).with_context(|| {
+                        format!("Unable to create rootless directory '{}'", dir)
+                    })?;
+                }
+                fs::create_dir_all("/var/lib/kubelet/device-plugins")
+                    .context("Unable to create /var/lib/kubelet/device-plugins")?;
+
+                // Override containers-storage.conf to prevent
+                // overlay-specific options from leaking into vfs mode.
+                // Written to the run directory (not /etc/containers/) to
+                // avoid permission issues inside rootlesskit copy-ups.
+                let storage_conf = config.root().join("storage.conf");
+                fs::write(&storage_conf, "[storage]\ndriver = \"vfs\"\n")
+                    .context("Unable to write rootless storage.conf")?;
+                // SAFETY: called before any threads are spawned.
+                unsafe { std::env::set_var("CONTAINERS_STORAGE_CONF", &storage_conf) };
+
+                // On NixOS, /etc/hosts is a symlink into the read-only nix
+                // store. Replace it with a regular file so multi-node can
+                // write host entries.
+                let hosts_path = Self::hosts();
+                if hosts_path.is_symlink() {
+                    let content = read_to_string(&hosts_path).unwrap_or_default();
+                    fs::remove_file(&hosts_path).context("Unable to remove hosts symlink")?;
+                    fs::write(&hosts_path, content).context("Unable to write hosts file")?;
+                }
+            }
+        }
+
+        if !config.is_rootless() && !Self::in_container()? {
             for module in &["overlay", "br_netfilter", "ip_conntrack"] {
                 Self::modprobe(module)?;
             }
@@ -37,6 +95,8 @@ impl System {
             ] {
                 Self::sysctl_enable(sysctl)?;
             }
+        } else {
+            info!("Skipping modprobe and sysctl (containerized or rootless)");
         }
 
         let hosts = if config.multi_node() {
@@ -70,6 +130,24 @@ impl System {
         };
 
         Ok(Self { hosts })
+    }
+
+    /// Returns true if running inside a user namespace (uid 0 maps to
+    /// a non-zero host UID). Used to guard destructive host path cleanup
+    /// and to validate the KUBERNIX_ROOTLESS env var at startup.
+    ///
+    /// This function is intentionally side-effect-free (no logging)
+    /// because it may be called before the logger is initialized.
+    pub(crate) fn in_user_namespace() -> bool {
+        read_to_string("/proc/self/uid_map")
+            .map(|s| {
+                s.lines().any(|line| {
+                    let mut fields = line.split_whitespace();
+                    fields.next() == Some("0")
+                        && fields.next().is_some_and(|host_uid| host_uid != "0")
+                })
+            })
+            .unwrap_or(false)
     }
 
     /// Returns true if the process is running inside a container


### PR DESCRIPTION
Auto-detect rootless mode when running as non-root user via `getuid().is_root()`. A runtime-only `rootless` field on `Config` (`#[serde(skip)]`, `#[arg(skip)]`) threads the mode through every layer:
- **Kubelet**: `KubeletInUserNamespace` feature gate, `cgroupDriver: "none"`
- **CRI runtimes**: vfs storage driver, native snapshotter, NRI and hostport mapping disabled via config
- **CNI networking**: `ptp` plugin instead of `bridge`
- **kube-proxy**: Skipped entirely (requires `CAP_NET_ADMIN` for iptables)
- **System setup**: Skip modprobe, sysctl; recreate copy-up directories inside rootlesskit
- **Multi-node rootless**: Direct processes with `--hostname-override` (no container isolation)
- **CRI-O config**: Template `container_attach_socket_dir` and `namespaces_dir` instead of hardcoding `/var/run` paths
- **Cleanup**: Skip force-unmount in rootless mode

Prerequisites: cgroup v2 with user delegation, `kernel.unprivileged_userns_clone=1`.
ClusterIP-based Service routing is not supported without kube-proxy.

Adds rootless CI integration tests (single/multi-node, CRI-O + containerd) to the existing matrix.

Fixes #16