### PR TITLE
Fix CoreDNS readiness in rootless mode

### DIFF
--- a/src/assets/coredns.yml
+++ b/src/assets/coredns.yml
@@ -126,14 +126,8 @@ spec:
       - name: coredns
         image: registry.k8s.io/coredns/coredns:v1.12.0
         imagePullPolicy: IfNotPresent
-        resources:
-          limits:
-            memory: 170Mi
-          requests:
-            cpu: 100m
-            memory: 70Mi
-        args: [ "-conf", "/etc/coredns/Corefile" ]
-        volumeMounts:
+{resources}        args: [ "-conf", "/etc/coredns/Corefile" ]
+{env}        volumeMounts:
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true

--- a/src/coredns.rs
+++ b/src/coredns.rs
@@ -1,12 +1,11 @@
 //! CoreDNS addon deployment for the cluster.
 
-use crate::{config::Config, kubectl::Kubectl, network::Network};
+use crate::{
+    API_SERVER_PORT, config::Config, kubectl::Kubectl, network::Network, write_if_changed,
+};
 use anyhow::{Context, Result};
 use log::info;
-use std::{
-    fs::{self, create_dir_all},
-    net::Ipv4Addr,
-};
+use std::{fs::create_dir_all, net::Ipv4Addr};
 
 /// Deploys the CoreDNS addon to the cluster.
 pub struct CoreDns;
@@ -19,12 +18,9 @@ impl CoreDns {
         let dir = config.root().join("coredns");
         create_dir_all(&dir)?;
 
-        let yml = Self::render(network.dns()?);
+        let yml = Self::render(network.dns()?, config.is_rootless());
         let file = dir.join("coredns.yml");
-
-        if !file.exists() {
-            fs::write(&file, yml)?;
-        }
+        write_if_changed(&file, &yml)?;
 
         kubectl.apply(&file).context("Unable to deploy CoreDNS")?;
         kubectl.wait_ready("coredns")?;
@@ -32,8 +28,39 @@ impl CoreDns {
         Ok(())
     }
 
-    fn render(dns: Ipv4Addr) -> String {
-        format!(include_str!("assets/coredns.yml"), dns)
+    fn render(dns: Ipv4Addr, rootless: bool) -> String {
+        let env = if rootless {
+            format!(
+                concat!(
+                    "        env:\n",
+                    "        - name: KUBERNETES_SERVICE_HOST\n",
+                    "          value: \"127.0.0.1\"\n",
+                    "        - name: KUBERNETES_SERVICE_PORT\n",
+                    "          value: \"{}\"\n",
+                ),
+                API_SERVER_PORT,
+            )
+        } else {
+            String::new()
+        };
+        let resources = if rootless {
+            ""
+        } else {
+            concat!(
+                "        resources:\n",
+                "          limits:\n",
+                "            memory: 170Mi\n",
+                "          requests:\n",
+                "            cpu: 100m\n",
+                "            memory: 70Mi\n",
+            )
+        };
+        format!(
+            include_str!("assets/coredns.yml"),
+            dns,
+            env = env,
+            resources = resources,
+        )
     }
 }
 
@@ -44,19 +71,59 @@ mod tests {
     #[test]
     fn render_contains_dns_ip() {
         let ip = Ipv4Addr::new(10, 10, 1, 2);
-        let yml = CoreDns::render(ip);
+        let yml = CoreDns::render(ip, false);
         assert!(yml.contains("clusterIP: 10.10.1.2"));
         assert!(yml.contains("k8s-app: coredns"));
     }
 
     #[test]
     fn render_contains_resource_kinds() {
-        let yml = CoreDns::render(Ipv4Addr::new(10, 0, 0, 2));
+        let yml = CoreDns::render(Ipv4Addr::new(10, 0, 0, 2), false);
         assert!(yml.contains("kind: ServiceAccount"));
         assert!(yml.contains("kind: ClusterRole"));
         assert!(yml.contains("kind: ClusterRoleBinding"));
         assert!(yml.contains("kind: ConfigMap"));
         assert!(yml.contains("kind: Deployment"));
         assert!(yml.contains("kind: Service"));
+    }
+
+    #[test]
+    fn render_rootless_overrides_api_server_env() {
+        let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), true);
+        assert!(yml.contains("KUBERNETES_SERVICE_HOST"));
+        assert!(yml.contains("value: \"127.0.0.1\""));
+        assert!(yml.contains("KUBERNETES_SERVICE_PORT"));
+        assert!(yml.contains(&format!("value: \"{}\"", crate::API_SERVER_PORT)));
+    }
+
+    #[test]
+    fn render_non_rootless_no_api_server_env() {
+        let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), false);
+        assert!(!yml.contains("KUBERNETES_SERVICE_HOST"));
+    }
+
+    #[test]
+    fn render_non_rootless_has_resources() {
+        let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), false);
+        assert!(yml.contains("memory: 170Mi"));
+        assert!(yml.contains("cpu: 100m"));
+    }
+
+    #[test]
+    fn render_rootless_no_resources() {
+        let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), true);
+        assert!(!yml.contains("memory: 170Mi"));
+    }
+
+    #[test]
+    fn render_rootless_produces_valid_structure() {
+        let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), true);
+        assert!(yml.contains("KUBERNETES_SERVICE_HOST"));
+        assert!(!yml.contains("memory: 170Mi"));
+        let args_pos = yml.find("        args:").unwrap();
+        let env_pos = yml.find("        env:\n").unwrap();
+        let mounts_pos = yml.find("        volumeMounts:").unwrap();
+        assert!(args_pos < env_pos, "args must precede env");
+        assert!(env_pos < mounts_pos, "env must precede volumeMounts");
     }
 }

--- a/src/kubeconfig.rs
+++ b/src/kubeconfig.rs
@@ -5,7 +5,7 @@
 //! sets file permissions so non-root shell sessions can read them.
 
 use crate::{
-    Config,
+    API_SERVER_PORT, Config,
     kubectl::Kubectl,
     pki::{Identity, Pki},
 };
@@ -132,7 +132,7 @@ impl KubeConfig {
             "set-cluster",
             cluster,
             &format!("--certificate-authority={}", ca.display()),
-            &format!("--server=https://{}:6443", Ipv4Addr::LOCALHOST),
+            &format!("--server=https://{}:{API_SERVER_PORT}", Ipv4Addr::LOCALHOST),
             embed_certs,
         ])?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,9 @@ use system::System;
 
 const ROOTLESS_ENV: &str = "KUBERNIX_ROOTLESS";
 
+/// The port the API server listens on.
+pub(crate) const API_SERVER_PORT: u16 = 6443;
+
 use ::nix::{
     mount::{MntFlags, umount2},
     unistd::getuid,
@@ -196,33 +199,69 @@ impl Kubernix {
         let exe = std::env::current_exe().context("Unable to determine current executable")?;
         let args: Vec<String> = std::env::args().skip(1).collect();
 
-        let inner_cmd = format!(
-            "exec {} {}",
-            Self::shell_escape(&exe.display().to_string()),
-            args.iter()
-                .map(|a| Self::shell_escape(a))
-                .collect::<Vec<_>>()
-                .join(" "),
+        let kubernix_args = args
+            .iter()
+            .map(|a| Self::shell_escape(a))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let kubernix_exe = Self::shell_escape(&exe.display().to_string());
+
+        // Inside rootlesskit's cgroup namespace, evacuate processes from the
+        // namespace root into a child and enable controllers, then exec.
+        let rootlesskit_cmd = format!(
+            concat!(
+                "mount -t cgroup2 none /sys/fs/cgroup 2>/dev/null; ",
+                "mkdir -p /sys/fs/cgroup/kubernix; ",
+                "for p in $(cat /sys/fs/cgroup/cgroup.procs); do ",
+                "echo $p >/sys/fs/cgroup/kubernix/cgroup.procs 2>/dev/null; done; ",
+                "for c in memory cpu pids io; do ",
+                "echo \"+$c\" >/sys/fs/cgroup/cgroup.subtree_control 2>/dev/null; done; ",
+                "grep -q memory /sys/fs/cgroup/cgroup.subtree_control 2>/dev/null ",
+                "|| echo 'WARNING: cgroup memory controller not delegated, pods may fail' >&2; ",
+                "exec {} {}",
+            ),
+            kubernix_exe, kubernix_args,
         );
 
-        let mut cmd = Command::new("rootlesskit");
+        // Evacuate all processes from the scope's root cgroup into a child
+        // so we can enable controllers in subtree_control (cgroup v2's
+        // "no internal processes" rule forbids it otherwise). This must
+        // happen outside rootlesskit's cgroup namespace.
+        let outer_cmd = format!(
+            concat!(
+                "CGRP=/sys/fs/cgroup$(cat /proc/self/cgroup | cut -d: -f3); ",
+                "mkdir -p \"$CGRP/init\"; ",
+                "for p in $(cat \"$CGRP/cgroup.procs\"); do ",
+                "echo $p >\"$CGRP/init/cgroup.procs\" 2>/dev/null; done; ",
+                "for c in memory cpu pids io; do ",
+                "echo \"+$c\" >\"$CGRP/cgroup.subtree_control\" 2>/dev/null; done; ",
+                "grep -q memory \"$CGRP/cgroup.subtree_control\" 2>/dev/null ",
+                "|| echo 'WARNING: cgroup memory controller not delegated, pods may fail' >&2; ",
+                "exec rootlesskit --net=host --cgroupns ",
+                "--copy-up=/etc --copy-up=/run --copy-up=/var/cache ",
+                "--copy-up=/var/lib --copy-up=/var/log --copy-up=/var/run ",
+                "bash -c {}",
+            ),
+            Self::shell_escape(&rootlesskit_cmd),
+        );
+
+        let mut cmd = Command::new("systemd-run");
         cmd.args([
-            "--net=host",
-            "--copy-up=/etc",
-            "--copy-up=/run",
-            "--copy-up=/var/cache",
-            "--copy-up=/var/lib",
-            "--copy-up=/var/log",
-            "--copy-up=/var/run",
+            "--user",
+            "--scope",
+            "-p",
+            "Delegate=yes",
+            "--",
             "bash",
             "-c",
-            &inner_cmd,
+            &outer_cmd,
         ]);
         cmd.env(ROOTLESS_ENV, "1");
 
         let status = cmd.status().context(
-            "Failed to start rootlesskit. Is it installed? \
-             (rootless mode requires rootlesskit)",
+            "Failed to start rootless session. \
+             Rootless mode requires systemd-run (with an active user session) \
+             and rootlesskit to be installed",
         )?;
 
         // No Kubernix struct or other Drop-bearing resources exist yet,
@@ -464,6 +503,34 @@ impl Kubernix {
         }
     }
 
+    /// Remove CRI storage directories while still inside the user namespace.
+    /// Image layers contain files owned by unmapped uids that become
+    /// unremovable after rootlesskit exits. Unmounts any lingering
+    /// container overlays first so remove_dir_all can succeed.
+    fn cleanup_rootless_storage(&self) {
+        if !self.config.is_rootless() {
+            return;
+        }
+        debug!("Removing rootless CRI storage");
+        let root = self.config.root();
+        for entry in ["crio", "containerd"] {
+            let dir = root.join(entry);
+            if !dir.exists() {
+                continue;
+            }
+            if let Ok(mounts) = Self::read_mount_points(&dir) {
+                for mp in &mounts {
+                    if let Err(e) = umount2(mp.as_path(), MntFlags::MNT_DETACH) {
+                        debug!("Unable to umount '{}': {}", mp.display(), e);
+                    }
+                }
+            }
+            if let Err(e) = fs::remove_dir_all(&dir) {
+                debug!("Unable to remove '{}': {}", dir.display(), e);
+            }
+        }
+    }
+
     /// Read mount points from /proc/mounts filtered by the given root path,
     /// sorted deepest-first for safe unmounting.
     fn read_mount_points(root: &Path) -> Result<Vec<PathBuf>> {
@@ -505,6 +572,7 @@ impl Drop for Kubernix {
 
         self.stop();
         self.umount();
+        self.cleanup_rootless_storage();
         self.system.cleanup();
         info!("Cleanup done");
 


### PR DESCRIPTION
Without kube-proxy, the ClusterIP injected via `KUBERNETES_SERVICE_HOST` is unreachable. This overrides the env vars in the CoreDNS pod spec to point at the API server on localhost (`127.0.0.1:6443`) when running rootless.