### PR TITLE
Enable CoreDNS integration testing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,10 @@ jobs:
         run: |
           echo "127.0.0.1 test" | sudo tee -a /etc/hosts
           sudo hostnamectl set-hostname test
+      - name: Free port 53 for CoreDNS
+        run: |
+          echo 'nameserver 8.8.8.8' | sudo tee /etc/resolv.conf
+          sudo systemctl stop systemd-resolved || true
       - name: Prepare the system
         if: ${{ !matrix.rootless }}
         run: sudo contrib/prepare-system
@@ -313,11 +317,12 @@ jobs:
         run: |
           sudo sh -c 'echo "kernel.unprivileged_userns_clone=1" > /etc/sysctl.d/rootless.conf && sysctl --system'
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          sudo sysctl -w net.ipv4.ip_unprivileged_port_start=53
+          sudo systemctl disable --now apparmor || true
           sudo sh -c 'mkdir -p /etc/systemd/system/user-.slice.d && printf "[Slice]\nDelegate=yes\n" > /etc/systemd/system/user-.slice.d/delegate.conf && systemctl daemon-reload'
       - name: Run integration test
         run: |
-          # --addons with no value disables addon deployment (empty list)
-          ${{ !matrix.rootless && 'sudo -E env "PATH=$PATH"' || '' }} ./kubernix --log-level=debug --no-shell --addons --nodes=${{ matrix.nodes }} --cri-runtime=${{ matrix.cri_runtime }} &
+          ${{ !matrix.rootless && 'sudo -E env "PATH=$PATH"' || '' }} ./kubernix --log-level=debug --no-shell --nodes=${{ matrix.nodes }} --cri-runtime=${{ matrix.cri_runtime }} &
           KUBERNIX_PID=$!
           timeout 600 bash -c 'while [ ! -f kubernix-run/kubernix.pid ]; do sleep 1; done'
           echo "Cluster is up, running checks"
@@ -337,6 +342,18 @@ jobs:
             echo "FAIL: unhealthy pods: $UNHEALTHY"
             exit 1
           fi
+
+          echo "Asserting CoreDNS is ready..."
+          if ! timeout 110 bash -c 'until kubectl -n kube-system wait --for=condition=Ready pod -l k8s-app=coredns --timeout=5s 2>/dev/null; do sleep 2; done'; then
+            echo "=== CoreDNS pod describe ==="
+            kubectl describe pod -n kube-system -l k8s-app=coredns || true
+            echo "=== CoreDNS logs ==="
+            kubectl logs -n kube-system -l k8s-app=coredns --tail=100 || true
+            echo "=== kubernetes endpoints ==="
+            kubectl get endpoints kubernetes || true
+            exit 1
+          fi
+          echo "CoreDNS is ready"
 
           echo "All assertions passed"
           ${{ !matrix.rootless && 'sudo' || '' }} kill $KUBERNIX_PID

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -13,6 +13,7 @@ with pkgs;
   etcd
   iproute2
   iptables
+  jq
   kmod
   kubectl
   kubernetes

--- a/src/assets/containerd.toml
+++ b/src/assets/containerd.toml
@@ -12,6 +12,7 @@ snapshotter = "{snapshotter}"
 [plugins."io.containerd.cri.v1.runtime"]
 enable_unprivileged_ports = true
 enable_unprivileged_icmp = true
+disable_apparmor = {disable_apparmor}
 
 [plugins."io.containerd.cri.v1.runtime".cni]
 bin_dirs = ["{plugin_dir}"]

--- a/src/assets/crun-rootless.sh
+++ b/src/assets/crun-rootless.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+command -v jq >/dev/null 2>&1 || { echo "crun-rootless: jq required but not found" >&2; exit 127; }
+bundle=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--bundle" ]; then bundle="$arg"; fi
+  case "$arg" in --bundle=*) bundle="${arg#--bundle=}" ;; esac
+  prev="$arg"
+done
+if [ -n "$bundle" ] && [ -f "$bundle/config.json" ]; then
+  cfg="$bundle/config.json"
+  jq '
+    del(.process.oomScoreAdj)
+    | if [.linux.namespaces[]? | select(.type=="uts")] | length == 0
+      then .linux.namespaces = [{"type":"uts"}] + .linux.namespaces
+      else . end
+  ' "$cfg" > "$cfg.tmp" && mv "$cfg.tmp" "$cfg"
+  for m in network:net uts:uts ipc:ipc pid:pid; do
+    oci="${m%%:*}"; proc="${m##*:}"
+    self=$(stat -Lc %i "/proc/self/ns/$proc" 2>/dev/null) || continue
+    path=$(jq -r ".linux.namespaces[]? | select(.type==\"$oci\" and .path) | .path" "$cfg" 2>/dev/null)
+    [ -n "$path" ] || continue
+    target=$(stat -Lc %i "$path" 2>/dev/null) || continue
+    if [ "$self" = "$target" ]; then
+      jq --arg t "$oci" --arg p "$path" \
+        'del(.linux.namespaces[] | select(.type==$t and .path==$p))' \
+        "$cfg" > "$cfg.tmp" && mv "$cfg.tmp" "$cfg"
+    fi
+  done
+fi
+exec __CRUN_PATH__ "$@"

--- a/src/containerd.rs
+++ b/src/containerd.rs
@@ -88,16 +88,35 @@ impl Containerd {
         let cni_conf_dir = dir.join("cni");
         let socket = Self::socket(config, network, node)?;
 
+        // In rootless mode, kubelet sends oomScoreAdj via CRI, containerd
+        // passes it to the OCI spec, and crun fails writing
+        // /proc/self/oom_score_adj in a user namespace. Wrap crun to patch
+        // config.json before exec (strip oomScoreAdj, fix namespace config).
+        let runtime_path = if config.is_rootless() {
+            dir.join("crun-rootless").display().to_string()
+        } else {
+            crun_path.clone()
+        };
+
         if !dir.exists() {
             create_dir_all(&dir)?;
             create_dir_all(&cni_conf_dir)?;
 
-            let snapshotter =
-                if config.multi_node() || config.is_rootless() || System::in_container()? {
-                    "native"
-                } else {
-                    "overlayfs"
-                };
+            if config.is_rootless() {
+                let wrapper = dir.join("crun-rootless");
+                let script =
+                    include_str!("assets/crun-rootless.sh").replace("__CRUN_PATH__", &crun_path);
+                fs::write(&wrapper, script)?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o755))?;
+                }
+            }
+
+            // containerd 2.3.3 native snapshotter fails with "no unpack
+            // platforms defined"; overlayfs works in all modes.
+            let snapshotter = "overlayfs";
             fs::write(
                 &config_file,
                 format!(
@@ -107,13 +126,25 @@ impl Containerd {
                     socket = socket,
                     plugin_dir = plugin_dir,
                     cni_conf_dir = cni_conf_dir.display(),
-                    runtime_path = crun_path,
+                    runtime_path = runtime_path,
                     snapshotter = snapshotter,
+                    disable_apparmor = config.is_rootless(),
                     disable_nri = config.is_rootless(),
                 ),
             )?;
 
             cri::write_pod_network_config(config, &cni_conf_dir, &node_name, node, network)?;
+        }
+
+        // containerd-shim-runc-v2 hardcodes its socket path to /run/containerd/s/.
+        // rootlesskit's --copy-up=/run creates an overlay that preserves
+        // host-owned subdirectories with wrong ownership (host root maps to
+        // UID 65534). Recreate with correct ownership. Safe: runs inside
+        // rootlesskit's private mount namespace before containerd starts.
+        if config.is_rootless() && create_dir_all("/run/containerd/s").is_err() {
+            fs::remove_dir_all("/run/containerd")
+                .context("Failed to remove host-owned /run/containerd")?;
+            create_dir_all("/run/containerd/s")?;
         }
 
         let config_arg = format!("--config={}", config_file.display());

--- a/src/coredns.rs
+++ b/src/coredns.rs
@@ -29,20 +29,19 @@ impl CoreDns {
     }
 
     fn render(dns: Ipv4Addr, rootless: bool) -> String {
-        let env = if rootless {
-            format!(
-                concat!(
-                    "        env:\n",
-                    "        - name: KUBERNETES_SERVICE_HOST\n",
-                    "          value: \"127.0.0.1\"\n",
-                    "        - name: KUBERNETES_SERVICE_PORT\n",
-                    "          value: \"{}\"\n",
-                ),
-                API_SERVER_PORT,
-            )
-        } else {
-            String::new()
-        };
+        // CoreDNS uses hostNetwork, so it can always reach the API server
+        // at 127.0.0.1. Setting these env vars explicitly avoids depending
+        // on kube-proxy ClusterIP routing being ready when CoreDNS starts.
+        let env = format!(
+            concat!(
+                "        env:\n",
+                "        - name: KUBERNETES_SERVICE_HOST\n",
+                "          value: \"127.0.0.1\"\n",
+                "        - name: KUBERNETES_SERVICE_PORT\n",
+                "          value: \"{}\"\n",
+            ),
+            API_SERVER_PORT,
+        );
         let resources = if rootless {
             ""
         } else {
@@ -88,18 +87,14 @@ mod tests {
     }
 
     #[test]
-    fn render_rootless_overrides_api_server_env() {
-        let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), true);
-        assert!(yml.contains("KUBERNETES_SERVICE_HOST"));
-        assert!(yml.contains("value: \"127.0.0.1\""));
-        assert!(yml.contains("KUBERNETES_SERVICE_PORT"));
-        assert!(yml.contains(&format!("value: \"{}\"", crate::API_SERVER_PORT)));
-    }
-
-    #[test]
-    fn render_non_rootless_no_api_server_env() {
-        let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), false);
-        assert!(!yml.contains("KUBERNETES_SERVICE_HOST"));
+    fn render_always_sets_api_server_env() {
+        for rootless in [true, false] {
+            let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), rootless);
+            assert!(yml.contains("KUBERNETES_SERVICE_HOST"));
+            assert!(yml.contains("value: \"127.0.0.1\""));
+            assert!(yml.contains("KUBERNETES_SERVICE_PORT"));
+            assert!(yml.contains(&format!("value: \"{}\"", crate::API_SERVER_PORT)));
+        }
     }
 
     #[test]
@@ -116,14 +111,15 @@ mod tests {
     }
 
     #[test]
-    fn render_rootless_produces_valid_structure() {
-        let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), true);
-        assert!(yml.contains("KUBERNETES_SERVICE_HOST"));
-        assert!(!yml.contains("memory: 170Mi"));
-        let args_pos = yml.find("        args:").unwrap();
-        let env_pos = yml.find("        env:\n").unwrap();
-        let mounts_pos = yml.find("        volumeMounts:").unwrap();
-        assert!(args_pos < env_pos, "args must precede env");
-        assert!(env_pos < mounts_pos, "env must precede volumeMounts");
+    fn render_produces_valid_structure() {
+        for rootless in [true, false] {
+            let yml = CoreDns::render(Ipv4Addr::new(10, 10, 1, 2), rootless);
+            assert!(yml.contains("KUBERNETES_SERVICE_HOST"));
+            let args_pos = yml.find("        args:").unwrap();
+            let env_pos = yml.find("        env:\n").unwrap();
+            let mounts_pos = yml.find("        volumeMounts:").unwrap();
+            assert!(args_pos < env_pos, "args must precede env");
+            assert!(env_pos < mounts_pos, "env must precede volumeMounts");
+        }
     }
 }


### PR DESCRIPTION
Deploy and verify CoreDNS across all 8 CI integration test matrix
entries (2 CRI runtimes x 2 node counts x rootless/non-rootless).

- Stop systemd-resolved to free port 53, set unprivileged port start
  to 53 for rootless CoreDNS with hostNetwork
- Assert CoreDNS pod readiness (kubectl wait) with diagnostic dump
  on timeout
- Always use overlayfs snapshotter for containerd (native is broken
  in 2.3.3)
- Wrap crun for rootless containerd to patch OCI config.json: strip
  oomScoreAdj, ensure sandbox UTS namespace, remove same-namespace
  joins that fail under rootlesskit
- Fix containerd shim socket permissions in rootless mode
- Disable AppArmor and NRI for rootless containerd
- Set KUBERNETES_SERVICE_HOST/PORT env vars unconditionally for
  CoreDNS (hostNetwork always reaches API server at 127.0.0.1)