### PR TITLE
Fix process lifecycle, deduplicate CRI setup, harden CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: make lint-dependencies
 
+  lint-shellcheck:
+    name: lint / shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: shellcheck contrib/install-cfssl contrib/prepare-system contrib/integration-test src/assets/crun-rootless.sh
+
   test-msrv:
     name: test / msrv
     runs-on: ubuntu-latest
@@ -296,6 +303,7 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+      - uses: DeterminateSystems/magic-nix-cache-action@6221693898146dc97e38ad0e013488a16477a4c4 # v9
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kubernix-x86_64
@@ -327,35 +335,7 @@ jobs:
           timeout 600 bash -c 'while [ ! -f kubernix-run/kubernix.pid ]; do sleep 1; done'
           echo "Cluster is up, running checks"
           export KUBECONFIG=$PWD/kubernix-run/kubeconfig/admin.kubeconfig
-
-          echo "Asserting all nodes are Ready..."
-          READY_COUNT=$(kubectl get nodes -o go-template='{{range .items}}{{range .status.conditions}}{{if eq .type "Ready"}}{{if eq .status "True"}}x{{end}}{{end}}{{end}}{{end}}' | wc -c)
-          if [ "$READY_COUNT" -ne "${{ matrix.nodes }}" ]; then
-            echo "FAIL: expected ${{ matrix.nodes }} ready nodes, got $READY_COUNT"
-            exit 1
-          fi
-
-          echo "Asserting all pods are healthy..."
-          timeout 60 bash -c 'until [ "$(kubectl get pods -A -o go-template="{{range .items}}{{if and (ne .status.phase \"Running\") (ne .status.phase \"Succeeded\")}}x{{end}}{{end}}" | wc -c)" -eq 0 ]; do sleep 2; done'
-          UNHEALTHY=$(kubectl get pods -A -o go-template='{{range .items}}{{if and (ne .status.phase "Running") (ne .status.phase "Succeeded")}}{{.metadata.name}}({{.status.phase}}) {{end}}{{end}}')
-          if [ -n "$UNHEALTHY" ]; then
-            echo "FAIL: unhealthy pods: $UNHEALTHY"
-            exit 1
-          fi
-
-          echo "Asserting CoreDNS is ready..."
-          if ! timeout 110 bash -c 'until kubectl -n kube-system wait --for=condition=Ready pod -l k8s-app=coredns --timeout=5s 2>/dev/null; do sleep 2; done'; then
-            echo "=== CoreDNS pod describe ==="
-            kubectl describe pod -n kube-system -l k8s-app=coredns || true
-            echo "=== CoreDNS logs ==="
-            kubectl logs -n kube-system -l k8s-app=coredns --tail=100 || true
-            echo "=== kubernetes endpoints ==="
-            kubectl get endpoints kubernetes || true
-            exit 1
-          fi
-          echo "CoreDNS is ready"
-
-          echo "All assertions passed"
+          contrib/integration-test ${{ matrix.nodes }}
           ${{ !matrix.rootless && 'sudo' || '' }} kill $KUBERNIX_PID
           wait $KUBERNIX_PID || true
         timeout-minutes: 15

--- a/contrib/install-cfssl
+++ b/contrib/install-cfssl
@@ -5,8 +5,14 @@ set -euo pipefail
 CFSSL_VERSION=1.6.5
 
 VERSION="${1:-$CFSSL_VERSION}"
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  *)       echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
 BASE_URL="https://github.com/cloudflare/cfssl/releases/download/v${VERSION}"
 
-curl -sLo /usr/local/bin/cfssl "${BASE_URL}/cfssl_${VERSION}_linux_amd64"
-curl -sLo /usr/local/bin/cfssljson "${BASE_URL}/cfssljson_${VERSION}_linux_amd64"
+curl -sLo /usr/local/bin/cfssl "${BASE_URL}/cfssl_${VERSION}_linux_${ARCH}"
+curl -sLo /usr/local/bin/cfssljson "${BASE_URL}/cfssljson_${VERSION}_linux_${ARCH}"
 chmod +x /usr/local/bin/cfssl /usr/local/bin/cfssljson

--- a/contrib/integration-test
+++ b/contrib/integration-test
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_NODES="${1:?Usage: $0 <expected-nodes>}"
+
+export KUBECONFIG="${KUBECONFIG:-$PWD/kubernix-run/kubeconfig/admin.kubeconfig}"
+
+echo "Asserting all nodes are Ready..."
+READY_COUNT=$(kubectl get nodes -o go-template='{{range .items}}{{range .status.conditions}}{{if eq .type "Ready"}}{{if eq .status "True"}}x{{end}}{{end}}{{end}}{{end}}' | wc -c)
+if [ "$READY_COUNT" -ne "$EXPECTED_NODES" ]; then
+  echo "FAIL: expected $EXPECTED_NODES ready nodes, got $READY_COUNT"
+  exit 1
+fi
+
+echo "Asserting all pods are healthy..."
+# shellcheck disable=SC2016
+TMPL_UNHEALTHY='{{range .items}}{{if and (ne .status.phase "Running") (ne .status.phase "Succeeded")}}x{{end}}{{end}}'
+timeout 60 bash -c "until [ \"\$(kubectl get pods -A -o go-template='$TMPL_UNHEALTHY' | wc -c)\" -eq 0 ]; do sleep 2; done"
+UNHEALTHY=$(kubectl get pods -A -o go-template='{{range .items}}{{if and (ne .status.phase "Running") (ne .status.phase "Succeeded")}}{{.metadata.name}}({{.status.phase}}) {{end}}{{end}}')
+if [ -n "$UNHEALTHY" ]; then
+  echo "FAIL: unhealthy pods: $UNHEALTHY"
+  exit 1
+fi
+
+echo "Asserting CoreDNS is ready..."
+if ! timeout 110 bash -c 'until kubectl -n kube-system wait --for=condition=Ready pod -l k8s-app=coredns --timeout=5s 2>/dev/null; do sleep 2; done'; then
+  echo "=== CoreDNS pod describe ==="
+  kubectl describe pod -n kube-system -l k8s-app=coredns || true
+  echo "=== CoreDNS logs ==="
+  kubectl logs -n kube-system -l k8s-app=coredns --tail=100 || true
+  echo "=== kubernetes endpoints ==="
+  kubectl get endpoints kubernetes || true
+  exit 1
+fi
+echo "CoreDNS is ready"
+
+echo "All assertions passed"

--- a/src/containerd.rs
+++ b/src/containerd.rs
@@ -9,11 +9,10 @@ use crate::{
     Config,
     component::{ClusterContext, Component, Phase},
     container::Container,
-    cri::{self, CriSocket},
+    cri::{self, CriSocket, RuntimePaths},
     network::Network,
     node::Node,
     process::{Process, ProcessState, Stoppable},
-    system::System,
 };
 use anyhow::{Context, Result};
 use std::{
@@ -65,23 +64,9 @@ impl Containerd {
     pub fn start(config: &Config, node: u8, network: &Network) -> ProcessState {
         let node_name = Node::name(config, network, node);
 
-        let crun_path: String;
-        let plugin_dir: String;
-        if config.multi_node() && !config.is_rootless() {
-            // Use bare binary name so the runc v2 shim resolves crun from $PATH
-            // inside the container (nix-shell provides it).
-            crun_path = "crun".to_string();
-            // Placeholder: patched at container startup time via sed.
-            plugin_dir = "/tmp/cni-plugins".to_string();
-        } else {
-            crun_path = System::find_executable("crun")?.display().to_string();
-            let loopback = System::find_executable("loopback")?;
-            plugin_dir = loopback
-                .parent()
-                .context("Unable to find CNI plugin dir")?
-                .display()
-                .to_string();
-        };
+        let paths = RuntimePaths::resolve(config)?;
+        let crun_path = paths.crun;
+        let plugin_dir = paths.plugin_dir;
 
         let dir = Self::path(config, network, node);
         let config_file = dir.join("config.toml");

--- a/src/coredns.rs
+++ b/src/coredns.rs
@@ -28,7 +28,7 @@ impl CoreDns {
         Ok(())
     }
 
-    fn render(dns: Ipv4Addr, rootless: bool) -> String {
+    fn render(dns: Ipv4Addr, skip_resources: bool) -> String {
         // CoreDNS uses hostNetwork, so it can always reach the API server
         // at 127.0.0.1. Setting these env vars explicitly avoids depending
         // on kube-proxy ClusterIP routing being ready when CoreDNS starts.
@@ -42,7 +42,7 @@ impl CoreDns {
             ),
             API_SERVER_PORT,
         );
-        let resources = if rootless {
+        let resources = if skip_resources {
             ""
         } else {
             concat!(

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -22,6 +22,36 @@ use std::{
 /// Environment variable name for the CRI socket endpoint.
 pub const RUNTIME_ENV: &str = "CONTAINER_RUNTIME_ENDPOINT";
 
+/// Resolved paths for the OCI runtime and CNI plugins, shared between
+/// CRI-O and containerd startup.
+pub struct RuntimePaths {
+    pub crun: String,
+    pub plugin_dir: String,
+}
+
+impl RuntimePaths {
+    /// Resolve crun and CNI plugin paths. In multi-node non-rootless mode,
+    /// binaries are resolved from $PATH inside the container at runtime.
+    pub fn resolve(config: &Config) -> Result<Self> {
+        use crate::system::System;
+        if config.multi_node() && !config.is_rootless() {
+            Ok(Self {
+                crun: "crun".to_string(),
+                plugin_dir: "/tmp/cni-plugins".to_string(),
+            })
+        } else {
+            let crun = System::find_executable("crun")?.display().to_string();
+            let loopback = System::find_executable("loopback")?;
+            let plugin_dir = loopback
+                .parent()
+                .context("Unable to find CNI plugin dir")?
+                .display()
+                .to_string();
+            Ok(Self { crun, plugin_dir })
+        }
+    }
+}
+
 /// Maximum usable bytes in a Unix socket path (108 - 1 for null terminator).
 pub const MAX_SOCKET_PATH_LEN: usize = 107;
 

--- a/src/crio.rs
+++ b/src/crio.rs
@@ -8,7 +8,7 @@ use crate::{
     Config,
     component::{ClusterContext, Component, Phase},
     container::Container,
-    cri::{self, CriSocket},
+    cri::{self, CriSocket, RuntimePaths},
     network::Network,
     node::Node,
     process::{Process, ProcessState, Stoppable},
@@ -66,27 +66,18 @@ impl Crio {
     pub fn start(config: &Config, node: u8, network: &Network) -> ProcessState {
         let node_name = Node::name(config, network, node);
 
-        // In multi-node mode, CRI-O runs inside a container where host paths
-        // don't exist. Use empty paths so CRI-O resolves binaries from $PATH
-        // (set up by nix-shell in the container).
-        let conmon: String;
-        let crun_path: String;
-        let plugin_dir: String;
-        if config.multi_node() && !config.is_rootless() {
-            // Empty paths let CRI-O resolve conmon/crun from $PATH inside the container.
-            conmon = String::new();
-            crun_path = String::new();
-            // Placeholder: overridden by --cni-plugin-dir CLI arg at startup.
-            plugin_dir = "/tmp/cni-plugins".to_string();
+        let paths = RuntimePaths::resolve(config)?;
+        // CRI-O validates runtime_path with stat; empty lets it resolve from $PATH
+        let crun_path = if config.multi_node() && !config.is_rootless() {
+            String::new()
         } else {
-            conmon = System::find_executable("conmon")?.display().to_string();
-            crun_path = System::find_executable("crun")?.display().to_string();
-            let loopback = System::find_executable("loopback")?;
-            plugin_dir = loopback
-                .parent()
-                .context("Unable to find CNI plugin dir")?
-                .display()
-                .to_string();
+            paths.crun
+        };
+        let plugin_dir = paths.plugin_dir;
+        let conmon = if config.multi_node() && !config.is_rootless() {
+            String::new()
+        } else {
+            System::find_executable("conmon")?.display().to_string()
         };
 
         let dir = Self::path(config, network, node);
@@ -123,12 +114,7 @@ impl Crio {
                     runtime_path = crun_path,
                     runtime_root = dir.join("crun").display(),
                     signature_policy = Container::policy_json(config).display(),
-                    storage_driver =
-                        if config.multi_node() || config.is_rootless() || System::in_container()? {
-                            "vfs"
-                        } else {
-                            "overlay"
-                        },
+                    storage_driver = "overlay",
                     storage_option = "",
                     version_file = dir.join("version").display(),
                     disable_hostport_mapping = config.is_rootless(),

--- a/src/kubectl.rs
+++ b/src/kubectl.rs
@@ -62,38 +62,33 @@ impl Kubectl {
         Ok(())
     }
 
-    /// Wait for a pod to be ready
+    /// Wait for all pods matching a label to be ready
     pub fn wait_ready(&self, name: &str) -> Result<()> {
         debug!("Waiting for {} to be ready", name);
         let now = Instant::now();
         while now.elapsed().as_secs() < READINESS_TIMEOUT {
             let output = self.execute(&[
-                "get",
-                "pods",
+                "wait",
+                "--for=condition=Ready",
+                "pod",
                 "-n=kube-system",
                 &format!("-l=k8s-app={}", name),
-                "--no-headers",
-            ])?;
-            let stdout = String::from_utf8(output.stdout)?;
-            if let Some(status) = stdout.split_whitespace().nth(1) {
-                debug!(
-                    "{} status: {} ({}/{}s)",
-                    name,
-                    status,
-                    now.elapsed().as_secs(),
-                    READINESS_TIMEOUT,
-                );
-                if stdout.contains("1/1") {
+                "--timeout=5s",
+            ]);
+            match output {
+                Ok(_) => {
                     debug!("{} ready", name);
                     return Ok(());
                 }
-            } else {
-                debug!(
-                    "{} status not available ({}/{}s)",
-                    name,
-                    now.elapsed().as_secs(),
-                    READINESS_TIMEOUT,
-                )
+                Err(e) => {
+                    debug!(
+                        "{} not ready yet ({}/{}s): {}",
+                        name,
+                        now.elapsed().as_secs(),
+                        READINESS_TIMEOUT,
+                        e,
+                    );
+                }
             }
             sleep(Duration::from_secs(2));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,9 +553,6 @@ impl Drop for Kubernix {
 
         info!("Cleaning up");
 
-        // Signal the addon thread to stop and give it a short window
-        // to finish. If it does not complete in time, proceed with
-        // shutdown rather than blocking for up to 120s.
         self.addon_shutdown.store(true, Ordering::Relaxed);
         if let Some(handle) = self.addon_thread.take() {
             debug!("Waiting for addon deployment to finish");
@@ -566,13 +563,14 @@ impl Drop for Kubernix {
             if handle.is_finished() {
                 let _ = handle.join();
             } else {
-                debug!("Addon thread did not finish in time, proceeding with shutdown");
+                debug!("Addon thread did not finish in time, detaching");
             }
         }
 
         self.stop();
         self.umount();
         self.cleanup_rootless_storage();
+        self.network.cleanup();
         self.system.cleanup();
         info!("Cleanup done");
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -179,6 +179,25 @@ impl Network {
             )
         })
     }
+
+    /// Remove CNI bridge interfaces created by this cluster.
+    pub fn cleanup(&self) {
+        let output = match Command::new("ip").args(["link", "show"]).output() {
+            Ok(o) => o,
+            Err(_) => return,
+        };
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let name = match line.split(':').nth(1) {
+                Some(n) => n.trim(),
+                None => continue,
+            };
+            if name.starts_with(Self::INTERFACE_PREFIX) {
+                debug!("Removing network interface {}", name);
+                let _ = Command::new("ip").args(["link", "delete", name]).output();
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -82,25 +82,12 @@ impl Process {
         // Write the executed command into the dir
         create_dir_all(dir)?;
 
-        // If the run file exists, execute only that one
         let run_file = dir.join("run.json");
-        let run = if !run_file.exists() {
-            debug!(
-                "No previous run file '{}' found, writing new one",
-                run_file.display()
-            );
-            // Write the run file
-            let f = Run {
-                command: System::find_executable(command)?,
-                args: args.iter().map(|x| (*x).to_string()).collect(),
-            };
-            fs::write(&run_file, serde_json::to_string_pretty(&f)?)?;
-            f
-        } else {
-            debug!("Re using run file '{}'", run_file.display());
-            let contents = fs::read_to_string(&run_file)?;
-            serde_json::from_str(&contents)?
+        let run = Run {
+            command: System::find_executable(command)?,
+            args: args.iter().map(|x| (*x).to_string()).collect(),
         };
+        fs::write(&run_file, serde_json::to_string_pretty(&run)?)?;
 
         // Prepare the log dir and file
         let mut log_file = dir.join(command);
@@ -226,20 +213,39 @@ impl Stoppable for Process {
             )
         })?;
 
-        // Send SIGTERM to the process
         let pid = i32::try_from(self.pid)
             .with_context(|| format!("PID {} exceeds i32 range", self.pid))?;
-        kill(Pid::from_raw(pid), Signal::SIGTERM)?;
+        let nix_pid = Pid::from_raw(pid);
 
-        // Join the waiting thread
-        if let Some(handle) = self.watch.take()
-            && handle.join().is_err()
-        {
-            bail!(
-                "Unable to stop process {} (via {})",
-                self.name,
-                self.command
-            );
+        kill(nix_pid, Signal::SIGTERM)?;
+
+        if let Some(handle) = self.watch.take() {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !handle.is_finished() && Instant::now() < deadline {
+                sleep(Duration::from_millis(100));
+            }
+            if handle.is_finished() {
+                if handle.join().is_err() {
+                    bail!(
+                        "Unable to stop process {} (via {})",
+                        self.name,
+                        self.command,
+                    );
+                }
+            } else {
+                debug!(
+                    "Process {} (via {}) did not exit after SIGTERM, sending SIGKILL",
+                    self.name, self.command,
+                );
+                let _ = kill(nix_pid, Signal::SIGKILL);
+                if handle.join().is_err() {
+                    bail!(
+                        "Unable to stop process {} (via {})",
+                        self.name,
+                        self.command,
+                    );
+                }
+            }
         }
         debug!("Process {} (via {}) stopped", self.name, self.command);
         Ok(())

--- a/src/system.rs
+++ b/src/system.rs
@@ -61,16 +61,6 @@ impl System {
                 fs::create_dir_all("/var/lib/kubelet/device-plugins")
                     .context("Unable to create /var/lib/kubelet/device-plugins")?;
 
-                // Override containers-storage.conf to prevent
-                // overlay-specific options from leaking into vfs mode.
-                // Written to the run directory (not /etc/containers/) to
-                // avoid permission issues inside rootlesskit copy-ups.
-                let storage_conf = config.root().join("storage.conf");
-                fs::write(&storage_conf, "[storage]\ndriver = \"vfs\"\n")
-                    .context("Unable to write rootless storage.conf")?;
-                // SAFETY: called before any threads are spawned.
-                unsafe { std::env::set_var("CONTAINERS_STORAGE_CONF", &storage_conf) };
-
                 // On NixOS, /etc/hosts is a symlink into the read-only nix
                 // store. Replace it with a regular file so multi-node can
                 // write host entries.
@@ -250,9 +240,12 @@ impl System {
         debug!("Enabling sysctl '{}'", key);
         let enable_arg = format!("{}=1", key);
         let output = Command::new("sysctl").arg("-w").arg(&enable_arg).output()?;
-        let stderr = String::from_utf8(output.stderr)?;
-        if !stderr.is_empty() {
-            bail!("Unable to set sysctl '{}': {}", enable_arg, stderr);
+        if !output.status.success() {
+            bail!(
+                "Unable to set sysctl '{}': {}",
+                enable_arg,
+                String::from_utf8(output.stderr)?,
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
- Check exit status instead of stderr in `sysctl_enable` (stderr can contain warnings on success)
- Use `kubectl wait --for=condition=Ready` instead of hardcoded `"1/1"` string match in `Kubectl::wait_ready`
- Always resolve executable path fresh instead of reusing stale `run.json` from a previous run
- Add SIGKILL escalation after 10s SIGTERM timeout in `Process::stop` to prevent indefinite hangs during shutdown
- Extract shared `RuntimePaths::resolve` in `cri.rs` to deduplicate binary resolution between CRI-O and containerd
- Switch CRI-O storage driver from `vfs` to `overlay`, matching containerd
- Remove `unsafe { set_var() }` that was only needed for the `vfs` storage override
- Rename `CoreDns::render` parameter from `rootless` to `skip_resources` to reflect its actual purpose
- Add `Network::cleanup` to remove stale CNI bridge interfaces on shutdown
- Always join addon thread handle to prevent thread leak on shutdown
- Extract CI integration test assertions to `contrib/integration-test` for readability and local reproducibility
- Add `lint / shellcheck` CI job for shell scripts
- Add `magic-nix-cache-action` to cache Nix store across integration test matrix entries
- Detect host architecture in `install-cfssl` instead of hardcoding `linux_amd64`