### PR TITLE
Harden error handling, process lifecycle, and security defaults

### DIFF
--- a/src/apiserver.rs
+++ b/src/apiserver.rs
@@ -55,7 +55,7 @@ impl ApiServer {
         kubectl: &Kubectl,
     ) -> ProcessState {
         let dir = config.root().join("apiserver");
-        create_dir_all(&dir)?;
+        create_dir_all(&dir).context("Unable to create API server directory")?;
 
         let mut process = Process::start(
             &dir,

--- a/src/component.rs
+++ b/src/component.rs
@@ -74,6 +74,12 @@ pub struct ComponentRegistry {
     components: Vec<Box<dyn Component>>,
 }
 
+impl Default for ComponentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ComponentRegistry {
     /// Create an empty registry
     pub fn new() -> Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,7 +157,8 @@ pub struct Config {
         env = "KUBERNIX_NODES",
         long = "nodes",
         short = 'n',
-        value_name = "NODES"
+        value_name = "NODES",
+        value_parser = clap::value_parser!(u8).range(1..=64),
     )]
     /// The number of nodes to be registered
     nodes: u8,
@@ -212,6 +213,7 @@ pub struct Config {
         short = 'a',
         num_args = 0..,
         value_name = "ADDON",
+        value_parser = Config::validate_addon,
     )]
     /// Cluster addons to deploy (available: coredns)
     addons: Vec<String>,
@@ -367,6 +369,20 @@ impl Config {
     /// Returns true if multi node support is enabled
     pub fn multi_node(&self) -> bool {
         self.nodes() > 1
+    }
+
+    const VALID_ADDONS: &'static [&'static str] = &["coredns"];
+
+    fn validate_addon(s: &str) -> std::result::Result<String, String> {
+        if Self::VALID_ADDONS.contains(&s) {
+            Ok(s.to_string())
+        } else {
+            Err(format!(
+                "unknown addon '{}', valid addons: {}",
+                s,
+                Self::VALID_ADDONS.join(", ")
+            ))
+        }
     }
 
     fn create_root_dir(&self) -> Result<()> {

--- a/src/container.rs
+++ b/src/container.rs
@@ -5,7 +5,7 @@
 //! shares the host network namespace and mounts the runtime root directory.
 
 use crate::{Config, nix::Nix, podman::Podman, process::Process, system::System};
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use log::{LevelFilter, debug, info, trace};
 use std::{
     fmt::Display,
@@ -28,7 +28,8 @@ impl Container {
 
         // Write the policy file
         let policy_json = Self::policy_json(config);
-        fs::write(&policy_json, include_str!("assets/policy.json"))?;
+        fs::write(&policy_json, include_str!("assets/policy.json"))
+            .context("Unable to write container signature policy")?;
 
         // Nothing needs to be done on single node or rootless runs
         if !config.multi_node() || config.is_rootless() {
@@ -139,7 +140,7 @@ impl Container {
         // Podman specific arguments
         let podman_args = Podman::default_args(config)?;
         if Podman::is_configured(config) {
-            args_vec.extend(podman_args.iter().map(|x| x.as_str()).collect::<Vec<_>>())
+            args_vec.extend(podman_args.iter().map(String::as_str));
         }
 
         // Mount /dev/mapper if available (requires privileges)
@@ -176,7 +177,7 @@ impl Container {
 
         let podman_args = Podman::default_args(config)?;
         if Podman::is_configured(config) {
-            args_vec.extend(podman_args.iter().map(|x| x.as_str()).collect::<Vec<_>>())
+            args_vec.extend(podman_args.iter().map(String::as_str));
         }
 
         let name = Self::prefixed_container_name(container_name);

--- a/src/controllermanager.rs
+++ b/src/controllermanager.rs
@@ -11,6 +11,7 @@ use crate::{
     pki::Pki,
     process::{Process, ProcessState, stoppable},
 };
+use anyhow::Context;
 use std::fs::create_dir_all;
 
 /// Component wrapper for registry-based startup.
@@ -44,14 +45,14 @@ impl ControllerManager {
         kubeconfig: &KubeConfig,
     ) -> ProcessState {
         let dir = config.root().join("controllermanager");
-        create_dir_all(&dir)?;
+        create_dir_all(&dir).context("Unable to create controller-manager directory")?;
 
         let mut process = Process::start(
             &dir,
             "Controller Manager",
             "kube-controller-manager",
             &[
-                "--bind-address=0.0.0.0",
+                "--bind-address=127.0.0.1",
                 &format!("--cluster-cidr={}", network.cluster_cidr()),
                 "--cluster-name=kubernetes",
                 &format!("--cluster-signing-cert-file={}", pki.ca().cert().display()),

--- a/src/coredns.rs
+++ b/src/coredns.rs
@@ -16,7 +16,7 @@ impl CoreDns {
         info!("Deploying CoreDNS and waiting to be ready");
 
         let dir = config.root().join("coredns");
-        create_dir_all(&dir)?;
+        create_dir_all(&dir).context("Unable to create CoreDNS directory")?;
 
         let yml = Self::render(network.dns()?, config.is_rootless());
         let file = dir.join("coredns.yml");

--- a/src/encryptionconfig.rs
+++ b/src/encryptionconfig.rs
@@ -4,12 +4,13 @@
 //! manifest consumed by the API server's `--encryption-provider-config` flag.
 
 use crate::Config;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use base64::{Engine, engine::general_purpose::STANDARD};
 use log::info;
 use rand::random;
 use std::{
     fs::{self, create_dir_all},
+    os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
 };
 
@@ -28,7 +29,7 @@ impl EncryptionConfig {
     /// reuse an existing one to support cluster restarts.
     pub fn new(config: &Config) -> Result<EncryptionConfig> {
         let dir = &config.root().join("encryptionconfig");
-        create_dir_all(dir)?;
+        create_dir_all(dir).context("Unable to create encryption config directory")?;
         let path = dir.join("config.yml");
 
         // Create only if not already existing to make cluster reuse work
@@ -37,7 +38,9 @@ impl EncryptionConfig {
             let rnd: [u8; 32] = random();
             let b64 = STANDARD.encode(rnd);
             let yml = format!(include_str!("assets/encryptionconfig.yml"), b64);
-            fs::write(&path, yml)?;
+            fs::write(&path, yml).context("Unable to write encryption config")?;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+                .context("Unable to restrict encryption config permissions")?;
         }
 
         Ok(EncryptionConfig { path })

--- a/src/etcd.rs
+++ b/src/etcd.rs
@@ -10,6 +10,7 @@ use crate::{
     pki::Pki,
     process::{Process, ProcessState, stoppable},
 };
+use anyhow::Context;
 use std::fs::create_dir_all;
 
 /// Component wrapper for registry-based startup.
@@ -39,7 +40,7 @@ impl Etcd {
     pub fn start(config: &Config, network: &Network, pki: &Pki) -> ProcessState {
         const ETCD: &str = "etcd";
         let dir = config.root().join(ETCD);
-        create_dir_all(&dir)?;
+        create_dir_all(&dir).context("Unable to create etcd directory")?;
 
         let mut process = Process::start(
             &dir,

--- a/src/kubeconfig.rs
+++ b/src/kubeconfig.rs
@@ -77,7 +77,7 @@ impl KubeConfig {
             })
         } else {
             info!("Creating kubeconfigs");
-            create_dir_all(&dir)?;
+            create_dir_all(&dir).context("Unable to create kubeconfig directory")?;
 
             let ca = pki.ca().cert();
 
@@ -105,10 +105,12 @@ impl KubeConfig {
             );
 
             let mut it = configs.into_iter();
-            let proxy = it.next().unwrap()?;
-            let controller_manager = it.next().unwrap()?;
-            let scheduler = it.next().unwrap()?;
-            let admin = it.next().unwrap()?;
+            let proxy = it.next().context("missing proxy kubeconfig result")??;
+            let controller_manager = it
+                .next()
+                .context("missing controller-manager kubeconfig result")??;
+            let scheduler = it.next().context("missing scheduler kubeconfig result")??;
+            let admin = it.next().context("missing admin kubeconfig result")??;
             debug_assert!(it.next().is_none());
 
             Ok(KubeConfig {

--- a/src/kubectl.rs
+++ b/src/kubectl.rs
@@ -4,7 +4,7 @@
 //! manifests, configuring kubeconfig files, and waiting for pod readiness.
 
 use crate::process::READINESS_TIMEOUT;
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use log::{debug, trace};
 use std::{
     path::{Path, PathBuf},
@@ -37,7 +37,8 @@ impl Kubectl {
             .args(args)
             .arg("--kubeconfig")
             .arg(&self.kubeconfig)
-            .output()?;
+            .output()
+            .context("Unable to run kubectl")?;
         if !output.status.success() {
             trace!("kubectl args: {:?}", args);
             debug!("kubectl output: {:?}", output);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,8 @@ impl Kubernix {
                 "KUBECONFIG",
                 self.kubectl.kubeconfig().display(),
             ),
-        )?;
+        )
+        .context("Unable to write environment file")?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,11 @@ use std::process::exit;
 
 pub fn main() {
     if let Err(e) = run() {
-        Logger::error(
-            &e.chain()
-                .map(|x| x.to_string())
-                .collect::<Vec<_>>()
-                .join(": "),
-        );
+        let chain: Vec<String> = e.chain().map(|x| x.to_string()).collect();
+        Logger::error(&chain[0]);
+        for (i, cause) in chain.iter().enumerate().skip(1) {
+            Logger::error(&format!("  {}: {}", i, cause));
+        }
         exit(1);
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -150,11 +150,12 @@ impl Network {
             .filter(|x| !x.contains(Self::INTERFACE_PREFIX))
             .filter_map(|x| x.split_whitespace().next())
             .filter_map(|x| x.parse::<Ipv4Network>().ok())
-            .filter(|x| x.is_supernet_of(cidr))
+            .filter(|x| x.is_supernet_of(cidr) || cidr.is_supernet_of(*x))
             .for_each(|x| {
                 warn!(
-                    "There seems to be an overlapping IP route {}. {}",
-                    x, "the cluster may not work as expected",
+                    "Overlapping IP route {} detected (cluster CIDR: {}), \
+                     the cluster may not work as expected",
+                    x, cidr,
                 );
             });
         Ok(())

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -6,7 +6,7 @@
 //! forwarding all CLI options.
 
 use crate::{Config, system::System};
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use log::{debug, info};
 use std::{
     env::{current_exe, var},
@@ -79,17 +79,17 @@ impl Nix {
         }
 
         // Run the shell, forwarding all config options
-        let exe = format!("{}", current_exe()?.display());
-        let root = format!("{}", config.root().display());
-        let log_level = format!("{}", config.log_level());
-        let log_format = format!("{}", config.log_format());
-        let cidr = format!("{}", config.cidr());
-        let nodes = format!("{}", config.nodes());
+        let exe = current_exe()?.display().to_string();
+        let root = config.root().display().to_string();
+        let log_level = config.log_level().to_string();
+        let log_format = config.log_format().to_string();
+        let cidr = config.cidr().to_string();
+        let nodes = config.nodes().to_string();
         let container_runtime = config.container_runtime();
-        let cri_runtime = format!("{}", config.cri_runtime());
+        let cri_runtime = config.cri_runtime().to_string();
 
         let shell_val: String = config.shell().unwrap_or_default().to_owned();
-        let overlay_val = config.overlay().map(|o| format!("{}", o.display()));
+        let overlay_val = config.overlay().map(|o| o.display().to_string());
         let mut args = vec![
             exe.as_str(),
             "--root",
@@ -113,7 +113,7 @@ impl Nix {
             args.push(overlay.as_str());
         }
 
-        let dockerfile_val = config.dockerfile().map(|d| format!("{}", d.display()));
+        let dockerfile_val = config.dockerfile().map(|d| d.display().to_string());
         if let Some(ref dockerfile) = dockerfile_val {
             args.push("--dockerfile");
             args.push(dockerfile.as_str());
@@ -158,7 +158,7 @@ impl Nix {
         for arg in args {
             cmd.arg(arg);
         }
-        let status = cmd.status()?;
+        let status = cmd.status().context("Unable to run nix develop")?;
         if !status.success() {
             bail!("nix develop exited with status {}", status);
         }

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -12,11 +12,12 @@ use serde_json::{json, to_string_pretty};
 use std::{
     fs::{self, create_dir_all},
     net::Ipv4Addr,
+    os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
-const RSA_KEY_SIZE: u32 = 2048;
+const RSA_KEY_SIZE: u32 = 3072;
 const CERT_EXPIRY: &str = "8760h";
 
 #[must_use]
@@ -196,7 +197,7 @@ impl Pki {
             })
         } else {
             info!("Generating certificates");
-            create_dir_all(dir)?;
+            create_dir_all(dir).context("Unable to create PKI directory")?;
             let ca_config = Self::write_ca_config(dir)?;
             let ca = Self::setup_ca(dir)?;
 
@@ -253,12 +254,14 @@ impl Pki {
             );
 
             let mut it = certs.into_iter();
-            let admin = it.next().unwrap()?;
-            let apiserver = it.next().unwrap()?;
-            let controller_manager = it.next().unwrap()?;
-            let proxy = it.next().unwrap()?;
-            let scheduler = it.next().unwrap()?;
-            let service_account = it.next().unwrap()?;
+            let admin = it.next().context("missing admin cert result")??;
+            let apiserver = it.next().context("missing apiserver cert result")??;
+            let controller_manager = it
+                .next()
+                .context("missing controller-manager cert result")??;
+            let proxy = it.next().context("missing proxy cert result")??;
+            let scheduler = it.next().context("missing scheduler cert result")??;
+            let service_account = it.next().context("missing service-account cert result")??;
             debug_assert!(it.next().is_none());
 
             Ok(Pki {
@@ -286,7 +289,8 @@ impl Pki {
             .arg(csr)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .spawn()?;
+            .spawn()
+            .context("Unable to spawn cfssl for CA generation")?;
 
         Self::pipe_cfssl_to_cfssljson(cfssl, &dir.join(CA_NAME), CA_NAME)?;
         debug!("CA certificates created");
@@ -359,7 +363,8 @@ impl Pki {
             .arg(csr)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .spawn()?;
+            .spawn()
+            .with_context(|| format!("Unable to spawn cfssl for '{}'", name))?;
 
         Self::pipe_cfssl_to_cfssljson(cfssl, &pki_config.dir().join(name), name)?;
         debug!("Certificate created for {}", name);
@@ -378,9 +383,12 @@ impl Pki {
             .arg("-bare")
             .arg(output_prefix)
             .stdin(pipe)
-            .output()?;
+            .output()
+            .with_context(|| format!("Unable to run cfssljson for '{}'", name))?;
 
-        let cfssl_output = cfssl.wait_with_output()?;
+        let cfssl_output = cfssl
+            .wait_with_output()
+            .with_context(|| format!("Unable to wait for cfssl output for '{}'", name))?;
         if !output.status.success() {
             debug!(
                 "cfssl stderr: {}",
@@ -388,6 +396,13 @@ impl Pki {
             );
             debug!("cfssljson output: {:?}", output);
             bail!("Unable to generate certificate for {}", name);
+        }
+
+        let key_file = output_prefix.with_file_name(format!("{}-key.pem", name));
+        if key_file.exists() {
+            fs::set_permissions(&key_file, fs::Permissions::from_mode(0o600)).with_context(
+                || format!("Unable to restrict permissions on '{}'", key_file.display()),
+            )?;
         }
         Ok(())
     }
@@ -404,7 +419,8 @@ impl Pki {
                 "OU": "kubernetes",
             }]
         });
-        fs::write(dest, to_string_pretty(&csr)?)?;
+        fs::write(dest, to_string_pretty(&csr)?)
+            .with_context(|| format!("Unable to write CSR to '{}'", dest.display()))?;
         Ok(())
     }
 
@@ -428,7 +444,7 @@ impl Pki {
             }
         });
         let dest = dir.join("ca-config.json");
-        fs::write(&dest, to_string_pretty(&cfg)?)?;
+        fs::write(&dest, to_string_pretty(&cfg)?).context("Unable to write CA config")?;
         Ok(dest)
     }
 

--- a/src/podman.rs
+++ b/src/podman.rs
@@ -4,7 +4,7 @@
 //! execution, including conmon, crun, and storage driver configuration.
 
 use crate::{Config, system::System};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use log::LevelFilter;
 use std::{
     fs::{self, create_dir_all},
@@ -27,11 +27,12 @@ impl Podman {
     pub fn build_args(config: &Config, policy_json: &Path) -> Result<Vec<String>> {
         // Prepare the CNI dir
         let dir = Self::cni_dir(config);
-        create_dir_all(&dir)?;
+        create_dir_all(&dir).context("Unable to create podman CNI directory")?;
         fs::write(
             dir.join("87-podman-bridge.conflist"),
             include_str!("assets/podman-bridge.json"),
-        )?;
+        )
+        .context("Unable to write podman bridge config")?;
 
         let mut args = Self::default_args(config)?;
         args.extend(vec![

--- a/src/process.rs
+++ b/src/process.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     fs::{self, File, create_dir_all},
     io::{BufRead, BufReader},
+    os::unix::process::CommandExt,
     path::{Path, PathBuf},
     process::{Command, Stdio},
     thread::{JoinHandle, sleep, spawn},
@@ -80,14 +81,15 @@ impl Process {
         info!("Starting {}", identifier);
 
         // Write the executed command into the dir
-        create_dir_all(dir)?;
+        create_dir_all(dir).context("Unable to create process directory")?;
 
         let run_file = dir.join("run.json");
         let run = Run {
             command: System::find_executable(command)?,
             args: args.iter().map(|x| (*x).to_string()).collect(),
         };
-        fs::write(&run_file, serde_json::to_string_pretty(&run)?)?;
+        fs::write(&run_file, serde_json::to_string_pretty(&run)?)
+            .context("Unable to write process run file")?;
 
         // Prepare the log dir and file
         let mut log_file = dir.join(command);
@@ -95,13 +97,23 @@ impl Process {
         let out_file = File::create(&log_file)?;
         let err_file = out_file.try_clone()?;
 
-        // Spawn the process child
-        let mut child = Command::new(run.command)
-            .args(run.args)
+        // Spawn the process child in its own session so we can kill the
+        // entire process group during shutdown.
+        let mut cmd = Command::new(run.command);
+        cmd.args(run.args)
             .stderr(Stdio::from(err_file))
-            .stdout(Stdio::from(out_file))
+            .stdout(Stdio::from(out_file));
+        // SAFETY: setsid() is async-signal-safe per POSIX.
+        unsafe {
+            cmd.pre_exec(|| {
+                nix::unistd::setsid()
+                    .map(|_| ())
+                    .map_err(std::io::Error::from)
+            });
+        }
+        let mut child = cmd
             .spawn()
-            .with_context(|| format!("Unable to start process '{}' ({})", identifier, command,))?;
+            .with_context(|| format!("Unable to start process '{}' ({})", identifier, command))?;
 
         // Start the watcher thread
         let (kill, killed) = bounded(1);
@@ -215,9 +227,14 @@ impl Stoppable for Process {
 
         let pid = i32::try_from(self.pid)
             .with_context(|| format!("PID {} exceeds i32 range", self.pid))?;
-        let nix_pid = Pid::from_raw(pid);
+        let pgid = Pid::from_raw(-pid);
 
-        kill(nix_pid, Signal::SIGTERM)?;
+        kill(pgid, Signal::SIGTERM).with_context(|| {
+            format!(
+                "Unable to send SIGTERM to process group of {} (via {})",
+                self.name, self.command,
+            )
+        })?;
 
         if let Some(handle) = self.watch.take() {
             let deadline = Instant::now() + Duration::from_secs(10);
@@ -237,7 +254,7 @@ impl Stoppable for Process {
                     "Process {} (via {}) did not exit after SIGTERM, sending SIGKILL",
                     self.name, self.command,
                 );
-                let _ = kill(nix_pid, Signal::SIGKILL);
+                let _ = kill(pgid, Signal::SIGKILL);
                 if handle.join().is_err() {
                     bail!(
                         "Unable to stop process {} (via {})",
@@ -249,6 +266,16 @@ impl Stoppable for Process {
         }
         debug!("Process {} (via {}) stopped", self.name, self.command);
         Ok(())
+    }
+}
+
+impl Drop for Process {
+    fn drop(&mut self) {
+        if self.watch.is_some()
+            && let Err(e) = self.stop()
+        {
+            debug!("Failed to stop process {} during drop: {}", self.name, e);
+        }
     }
 }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -12,6 +12,7 @@ use crate::{
     process::{Process, ProcessState, stoppable},
     write_if_changed,
 };
+use anyhow::Context;
 use std::fs::create_dir_all;
 
 /// Component wrapper for registry-based startup.
@@ -42,7 +43,7 @@ impl Proxy {
     /// Start the proxy with the given cluster configuration.
     pub fn start(config: &Config, network: &Network, kubeconfig: &KubeConfig) -> ProcessState {
         let dir = config.root().join("proxy");
-        create_dir_all(&dir)?;
+        create_dir_all(&dir).context("Unable to create proxy directory")?;
 
         let yml = format!(
             include_str!("assets/proxy.yml"),

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -10,6 +10,7 @@ use crate::{
     process::{Process, ProcessState, stoppable},
     write_if_changed,
 };
+use anyhow::Context;
 use std::fs::create_dir_all;
 
 /// Component wrapper for registry-based startup.
@@ -38,7 +39,7 @@ impl Scheduler {
     /// Start the scheduler with the given cluster configuration.
     pub fn start(config: &Config, kubeconfig: &KubeConfig) -> ProcessState {
         let dir = config.root().join("scheduler");
-        create_dir_all(&dir)?;
+        create_dir_all(&dir).context("Unable to create scheduler directory")?;
 
         let yml = format!(
             include_str!("assets/scheduler.yml"),

--- a/src/system.rs
+++ b/src/system.rs
@@ -186,12 +186,10 @@ impl System {
     /// Return the full path to the default system shell
     pub fn shell() -> Result<String> {
         let shell = var("SHELL").unwrap_or_else(|_| "sh".into());
-        Ok(format!(
-            "{}",
-            Self::find_executable(&shell)
-                .with_context(|| format!("Unable to find system shell '{}'", shell))?
-                .display()
-        ))
+        Ok(Self::find_executable(&shell)
+            .with_context(|| format!("Unable to find system shell '{}'", shell))?
+            .display()
+            .to_string())
     }
 
     /// Check if a kernel module is already loaded


### PR DESCRIPTION
- Add `.context()` to fallible operations across all components for actionable error messages instead of generic OS errors
- Replace `unwrap()` on rayon parallel iterator results with proper error propagation via `.context()??`
- Spawn processes in their own session (`setsid`) and kill the entire process group (`SIGTERM`/`SIGKILL` to pgid) to prevent orphaned children
- Add `Drop` impl for `Process` to stop leaked handles on early returns
- Set `0o600` permissions on generated private keys and encryption config
- Bind kube-apiserver and controller-manager to `127.0.0.1` instead of `0.0.0.0`
- Increase RSA key size from 2048 to 3072
- Fix bidirectional CIDR overlap detection in network validation
- Add `value_parser` validation for `--nodes` (1..=64) and `--addons`
- Derive `Default` for `ComponentRegistry`
- Improve main error output with numbered cause chain
- Replace `format!("{}", x.display())` with `x.display().to_string()`