### PR TITLE
Improve security defaults, error context, and Kubernetes API alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -329,9 +329,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -578,7 +578,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -760,9 +760,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/apiserver.rs
+++ b/src/apiserver.rs
@@ -100,6 +100,7 @@ impl ApiServer {
                 &format!("--service-cluster-ip-range={}", network.service_cidr()),
                 &format!("--tls-cert-file={}", pki.apiserver().cert().display()),
                 &format!("--tls-private-key-file={}", pki.apiserver().key().display()),
+                "--profiling=false",
                 "--v=2",
             ],
         )?;

--- a/src/assets/crio.conf
+++ b/src/assets/crio.conf
@@ -230,19 +230,8 @@ gid_mappings = ""
 # value is 30s, whereas lower values are not considered by CRI-O.
 ctr_stop_timeout = 30
 
-# **DEPRECATED** this option is being replaced by manage_ns_lifecycle, which is described below.
-# manage_network_ns_lifecycle = false
-
-# manage_ns_lifecycle determines whether we pin and remove namespaces
-# and manage their lifecycle
-manage_ns_lifecycle = false
-
 # The directory where the state of the managed namespaces gets tracked.
-# Only used when manage_ns_lifecycle is true.
 namespaces_dir = "{namespaces_dir}"
-
-# pinns_path is the path to find the pinns binary, which is needed to manage namespace lifecycle
-pinns_path = ""
 
 # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
 # The runtime to use is picked based on the runtime_handler provided by the CRI.

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,7 +77,7 @@ impl fmt::Display for CriRuntime {
         .literal(styling::AnsiColor::Cyan.on_default().bold())
         .placeholder(styling::AnsiColor::Cyan.on_default())
 )]
-/// The global configuration
+/// Kubernix runtime configuration parsed from CLI arguments and config files.
 pub struct Config {
     #[command(subcommand)]
     /// All available subcommands
@@ -572,6 +572,27 @@ root = "root"
     fn rootless_set_and_get() -> Result<()> {
         let c = test_config_rootless()?;
         assert!(c.is_rootless());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_addon_known() {
+        assert!(Config::validate_addon("coredns").is_ok());
+    }
+
+    #[test]
+    fn validate_addon_unknown() {
+        let result = Config::validate_addon("invalid");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("unknown addon"));
+    }
+
+    #[test]
+    fn multi_node_threshold() -> Result<()> {
+        let mut c = test_config()?;
+        assert!(!c.multi_node());
+        c.nodes = 2;
+        assert!(c.multi_node());
         Ok(())
     }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -54,7 +54,7 @@ impl Container {
         if !file.exists() {
             if let Some(custom) = config.dockerfile() {
                 debug!("Using custom Dockerfile '{}'", custom.display());
-                fs::copy(custom, &file)?;
+                fs::copy(custom, &file).context("Unable to copy custom Dockerfile")?;
             } else {
                 fs::write(
                     &file,
@@ -63,7 +63,8 @@ impl Container {
                         nix = Nix::DIR,
                         root = DEFAULT_ROOT
                     ),
-                )?;
+                )
+                .context("Unable to write Dockerfile")?;
             }
         }
 
@@ -72,7 +73,7 @@ impl Container {
         // container image does not need.
         let dockerignore = config.root().join(".dockerignore");
         if !dockerignore.exists() {
-            fs::write(&dockerignore, "nix/.git\n")?;
+            fs::write(&dockerignore, "nix/.git\n").context("Unable to write .dockerignore")?;
         }
 
         // Prepare the arguments
@@ -81,7 +82,7 @@ impl Container {
         } else {
             vec!["build".into()]
         };
-        args.extend(vec![format!("-t={}", DEFAULT_IMAGE), ".".into()]);
+        args.extend([format!("-t={DEFAULT_IMAGE}"), ".".into()]);
         trace!("Container runtime build args: {:?}", args);
 
         // Run the build
@@ -144,7 +145,7 @@ impl Container {
         }
 
         // Mount /dev/mapper if available (requires privileges)
-        let dev_mapper = PathBuf::from("/").join("dev").join("mapper");
+        let dev_mapper = PathBuf::from("/dev/mapper");
         let arg_volume_dev_mapper = &Self::volume_arg(dev_mapper.display());
         if !config.is_rootless() && dev_mapper.exists() {
             args_vec.push(arg_volume_dev_mapper);
@@ -185,7 +186,7 @@ impl Container {
         let mut cmd_parts = vec![process_name.to_string()];
         cmd_parts.extend(args.iter().map(|a| a.to_string()));
         let run_cmd = cmd_parts.join(" ");
-        args_vec.extend(vec![
+        args_vec.extend([
             "exec",
             &name,
             "nix",

--- a/src/containerd.rs
+++ b/src/containerd.rs
@@ -84,18 +84,19 @@ impl Containerd {
         };
 
         if !dir.exists() {
-            create_dir_all(&dir)?;
-            create_dir_all(&cni_conf_dir)?;
+            create_dir_all(&dir).context("Unable to create containerd directory")?;
+            create_dir_all(&cni_conf_dir).context("Unable to create containerd CNI directory")?;
 
             if config.is_rootless() {
                 let wrapper = dir.join("crun-rootless");
                 let script =
                     include_str!("assets/crun-rootless.sh").replace("__CRUN_PATH__", &crun_path);
-                fs::write(&wrapper, script)?;
+                fs::write(&wrapper, script).context("Unable to write crun-rootless wrapper")?;
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
-                    fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o755))?;
+                    fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o755))
+                        .context("Unable to set crun-rootless wrapper permissions")?;
                 }
             }
 
@@ -116,7 +117,8 @@ impl Containerd {
                     disable_apparmor = config.is_rootless(),
                     disable_nri = config.is_rootless(),
                 ),
-            )?;
+            )
+            .context("Unable to write containerd config")?;
 
             cri::write_pod_network_config(config, &cni_conf_dir, &node_name, node, network)?;
         }
@@ -129,7 +131,7 @@ impl Containerd {
         if config.is_rootless() && create_dir_all("/run/containerd/s").is_err() {
             fs::remove_dir_all("/run/containerd")
                 .context("Failed to remove host-owned /run/containerd")?;
-            create_dir_all("/run/containerd/s")?;
+            create_dir_all("/run/containerd/s").context("Unable to create /run/containerd/s")?;
         }
 
         let config_arg = format!("--config={}", config_file.display());

--- a/src/crio.rs
+++ b/src/crio.rs
@@ -87,14 +87,14 @@ impl Crio {
         let socket = Self::socket(config, network, node)?;
 
         if !dir.exists() {
-            create_dir_all(&dir)?;
-            create_dir_all(&network_dir)?;
-            create_dir_all(&config_dir)?;
+            create_dir_all(&dir).context("Unable to create CRI-O directory")?;
+            create_dir_all(&network_dir).context("Unable to create CRI-O CNI directory")?;
+            create_dir_all(&config_dir).context("Unable to create CRI-O config directory")?;
 
             let attach_dir = dir.join("attach");
             let ns_dir = dir.join("ns");
-            create_dir_all(&attach_dir)?;
-            create_dir_all(&ns_dir)?;
+            create_dir_all(&attach_dir).context("Unable to create CRI-O attach directory")?;
+            create_dir_all(&ns_dir).context("Unable to create CRI-O namespace directory")?;
 
             let containers_dir = dir.join("containers");
             fs::write(
@@ -120,7 +120,8 @@ impl Crio {
                     disable_hostport_mapping = config.is_rootless(),
                     enable_nri = !config.is_rootless(),
                 ),
-            )?;
+            )
+            .context("Unable to write CRI-O config")?;
 
             cri::write_pod_network_config(config, &network_dir, &node_name, node, network)?;
         }

--- a/src/kubeconfig.rs
+++ b/src/kubeconfig.rs
@@ -156,8 +156,6 @@ impl KubeConfig {
 
         kubectl.config(&["use-context", context])?;
 
-        // Make kubeconfig readable for non-root users spawning
-        // additional shell sessions via `kubernix shell`.
         let file = File::open(&kubeconfig).context("Unable to open kubeconfig")?;
         fchmod(&file, Mode::from_bits_truncate(0o644))
             .context("Unable to set kubeconfig permissions")?;

--- a/src/kubelet.rs
+++ b/src/kubelet.rs
@@ -78,7 +78,7 @@ impl Kubelet {
             )
         }
 
-        create_dir_all(&dir)?;
+        create_dir_all(&dir).context("Unable to create kubelet directory")?;
 
         let identity = pki
             .kubelets()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,8 @@ pub(crate) fn write_if_changed(path: &std::path::Path, content: &str) -> anyhow:
     {
         return Ok(());
     }
-    std::fs::write(path, content)?;
+    std::fs::write(path, content)
+        .with_context(|| format!("Unable to write '{}'", path.display()))?;
     Ok(())
 }
 
@@ -375,7 +376,9 @@ impl Kubernix {
             }
             registry.register(Box::new(kubelet::KubeletComponent::new(node)));
         }
-        if !config.is_rootless() {
+        if config.is_rootless() {
+            debug!("Skipping kube-proxy in rootless mode (no iptables access)");
+        } else {
             registry.register(Box::new(proxy::ProxyComponent));
         }
         registry

--- a/src/network.rs
+++ b/src/network.rs
@@ -14,6 +14,9 @@ use std::{
     process::Command,
 };
 
+const ETCD_CLIENT_PORT: u16 = 2379;
+const ETCD_PEER_PORT: u16 = 2380;
+
 #[derive(Clone)]
 #[must_use]
 pub struct Network {
@@ -114,8 +117,8 @@ impl Network {
         }
 
         // Set the rest of the networking related adresses and paths
-        let etcd_client = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 2379);
-        let etcd_peer = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 2380);
+        let etcd_client = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), ETCD_CLIENT_PORT);
+        let etcd_peer = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), ETCD_PEER_PORT);
         let hostname = gethostname()
             .context("Unable to get hostname")?
             .to_str()
@@ -285,5 +288,28 @@ pub mod tests {
     fn subnet_prefix_too_small() {
         // /30 can hold 4 IPs; need 3 subnets, impossible
         assert!(Network::subnet_prefix(30, 1).is_err());
+    }
+
+    #[test]
+    fn cidrs_do_not_overlap() -> Result<()> {
+        let c = test_config()?;
+        let n = Network::new(&c)?;
+        let cluster = n.cluster_cidr();
+        let service = n.service_cidr();
+        assert!(
+            !cluster.is_supernet_of(*service) && !service.is_supernet_of(*cluster),
+            "cluster and service CIDRs must not overlap"
+        );
+        for pod in n.pod_cidrs() {
+            assert!(
+                !cluster.is_supernet_of(*pod) && !pod.is_supernet_of(*cluster),
+                "pod CIDR must not overlap with cluster CIDR"
+            );
+            assert!(
+                !service.is_supernet_of(*pod) && !pod.is_supernet_of(*service),
+                "pod CIDR must not overlap with service CIDR"
+            );
+        }
+        Ok(())
     }
 }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -29,14 +29,16 @@ impl Nix {
 
         // Write the configuration if not existing
         if !dir.exists() {
-            create_dir_all(&dir)?;
+            create_dir_all(&dir).context("Unable to create nix directory")?;
 
             fs::write(
                 dir.join("flake.nix"),
                 include_str!("../nix/runtime-flake.nix")
                     .replace("KUBERNIX_SYSTEM", Self::nix_system()?),
-            )?;
-            fs::write(dir.join("flake.lock"), include_str!("../flake.lock"))?;
+            )
+            .context("Unable to write flake.nix")?;
+            fs::write(dir.join("flake.lock"), include_str!("../flake.lock"))
+                .context("Unable to write flake.lock")?;
 
             for pkg in config.packages() {
                 if !pkg
@@ -54,7 +56,8 @@ impl Nix {
             fs::write(
                 dir.join("packages.nix"),
                 include_str!("../nix/packages.nix").replace("/* PACKAGES */", packages),
-            )?;
+            )
+            .context("Unable to write packages.nix")?;
 
             // Apply the overlay if existing
             let target_overlay = dir.join("overlay.nix");
@@ -62,13 +65,14 @@ impl Nix {
                 // User defined overlay
                 Some(overlay) => {
                     info!("Using custom overlay '{}'", overlay.display());
-                    fs::copy(overlay, target_overlay)?;
+                    fs::copy(overlay, &target_overlay).context("Unable to copy custom overlay")?;
                 }
 
                 // The default overlay
                 None => {
                     debug!("Using default overlay");
-                    fs::write(target_overlay, include_str!("../nix/overlay.nix"))?;
+                    fs::write(&target_overlay, include_str!("../nix/overlay.nix"))
+                        .context("Unable to write default overlay")?;
                 }
             }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -94,8 +94,10 @@ impl Process {
         // Prepare the log dir and file
         let mut log_file = dir.join(command);
         log_file.set_extension("log");
-        let out_file = File::create(&log_file)?;
-        let err_file = out_file.try_clone()?;
+        let out_file = File::create(&log_file).context("Unable to create process log file")?;
+        let err_file = out_file
+            .try_clone()
+            .context("Unable to clone process log file handle")?;
 
         // Spawn the process child in its own session so we can kill the
         // entire process group during shutdown.


### PR DESCRIPTION
- Remove deprecated manage_ns_lifecycle from CRI-O config
- Add --profiling=false to kube-apiserver
- Add .context() to bare ? operators across containerd, crio, kubelet, container, nix, process, and lib modules
- Add etcd port constants in network module
- Add debug log when skipping kube-proxy in rootless mode
- Simplify PathBuf construction and vec allocation in container module
- Add tests for addon validation, multi-node threshold, CIDR overlap
- Update dependencies