### PR TITLE
Update nixpkgs and auto-update README versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,12 +202,25 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: make lint-dependencies
 
+  lint-readme-versions:
+    name: lint / readme versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+      - run: make update-readme
+      - run: git diff --exit-code README.md
+
   lint-shellcheck:
     name: lint / shellcheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: shellcheck contrib/install-cfssl contrib/prepare-system contrib/integration-test src/assets/crun-rootless.sh
+      - run: shellcheck contrib/install-cfssl contrib/prepare-system contrib/integration-test src/assets/crun-rootless.sh hack/update-readme-versions.sh
 
   test-msrv:
     name: test / msrv

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ARGS ?=
 SUDO ?= sudo -E
-ZEITGEIST_VERSION ?= v0.7.0
+ZEITGEIST_VERSION ?= v0.8.0
 
 # Avoid cargo/nix warnings about HOME ownership when running via sudo
 ifeq ($(shell id -u),0)
@@ -37,6 +37,11 @@ help: ## Display this help.
 .PHONY: nix-update
 nix-update: ## Update pinned nixpkgs to latest nixpkgs-unstable.
 	nix flake update nixpkgs
+	$(MAKE) update-readme
+
+.PHONY: update-readme
+update-readme: ## Regenerate the README versions table from the nix devShell.
+	hack/update-readme-versions.sh
 
 ##@ Build targets:
 

--- a/README.md
+++ b/README.md
@@ -45,22 +45,22 @@ The following technology stack is currently being used:
 | cfssl           | v1.6.5   |
 | cni-plugins     | v1.9.1   |
 | conmon          | v2.2.1   |
-| conntrack-tools | v1.4.8   |
-| containerd      | v2.3.3   |
-| cri-o-wrapper   | v1.36.3  |
+| conntrack-tools | v1.4.9   |
+| containerd      | v2.3.4   |
+| cri-o-wrapper   | v1.36.4  |
 | cri-tools       | v1.36.0  |
-| crun            | v1.27.1  |
+| crun            | v1.29.1  |
 | etcd            | v3.6.14  |
 | iproute2        | v7.1.0   |
 | iptables        | v1.8.13  |
 | kmod            | v31      |
-| kubectl         | v1.36.3  |
-| kubernetes      | v1.36.3  |
+| kubectl         | v1.37.0  |
+| kubernetes      | v1.37.0  |
 | nss-cacert      | v3.126   |
-| podman          | v5.8.4   |
+| podman          | v5.8.6   |
 | rootlesskit     | v2.3.6   |
 | socat           | v1.8.1.3 |
-| sysctl          | v4.0.6   |
+| sysctl          | v4.0.7   |
 | util-linux      | v2.42.2  |
 
 Some other tools are not explicitly mentioned here, because they are no

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -7,7 +7,7 @@ dependencies:
         match: CFSSL_VERSION=
 
   - name: zeitgeist
-    version: 0.7.0
+    version: 0.8.0
     refPaths:
       - path: Makefile
         match: ZEITGEIST_VERSION \?= v

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786534138,
-        "narHash": "sha256-fBJMdnKUTUDtfi/BYLr71HLaC9dG382arxLF2Egg2uo=",
+        "lastModified": 1788254679,
+        "narHash": "sha256-i/lPJ4yC1NI7tS0lk88A8FK683Jlhy9LixP1D0kEYJ8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "044bfe75bfe4c7bbe043dc17b5e42ea823b84a09",
+        "rev": "f0e996ff59c7624eba9db8972e8f1623a69d3b83",
         "type": "github"
       },
       "original": {

--- a/hack/update-readme-versions.sh
+++ b/hack/update-readme-versions.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for cmd in nix jq; do
+    command -v "$cmd" >/dev/null 2>&1 || {
+        echo "error: $cmd is required but not found" >&2
+        exit 1
+    }
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+README="$ROOT_DIR/README.md"
+README_TMP="$README.tmp"
+
+trap 'rm -f "$README_TMP"' EXIT
+
+# Display-name overrides (nix pname -> README name).
+# These map nixpkgs internal pname values, not the attribute names in
+# packages.nix. If nixpkgs changes a pname, update this map.
+declare -A NAME_MAP=(
+    [cri-o]=cri-o-wrapper
+    [procps]=sysctl
+)
+
+# Packages excluded from the versions table
+declare -A EXCLUDE=(
+    [jq]=1
+)
+
+# Detect the current system architecture
+SYSTEM="$(nix eval --raw --impure --expr 'builtins.currentSystem')"
+
+# Query nix for all package versions from the devShell
+VERSIONS=$(nix eval --json ".#devShells.${SYSTEM}.default.buildInputs" \
+    --apply 'builtins.map (p: { name = p.pname or p.name; version = let v = p.version or ""; in if v == "" then "unknown" else v; })')
+
+# Apply name mapping and exclusions, then sort by display name
+ROWS=$(while IFS=$'\t' read -r name version; do
+    [[ -n "${EXCLUDE[$name]:-}" ]] && continue
+    display_name="${NAME_MAP[$name]:-$name}"
+    printf '%s\tv%s\n' "$display_name" "$version"
+done < <(echo "$VERSIONS" | jq -r '.[] | [.name, .version] | @tsv') | sort)
+
+if [[ -z "$ROWS" ]]; then
+    echo "error: no packages found in devShell" >&2
+    exit 1
+fi
+
+# Compute column widths (seeded from header text)
+HEADER_NAME="Application"
+HEADER_VER="Version"
+NAME_WIDTH=${#HEADER_NAME}
+VERSION_WIDTH=${#HEADER_VER}
+while IFS=$'\t' read -r name version; do
+    ((${#name} > NAME_WIDTH)) && NAME_WIDTH=${#name}
+    ((${#version} > VERSION_WIDTH)) && VERSION_WIDTH=${#version}
+done <<< "$ROWS"
+
+# Build the table with dynamic widths
+SEP_NAME=$(printf '%*s' "$NAME_WIDTH" '' | tr ' ' '-')
+SEP_VER=$(printf '%*s' "$VERSION_WIDTH" '' | tr ' ' '-')
+
+TABLE=$(
+    printf '| %-*s | %-*s |' "$NAME_WIDTH" "$HEADER_NAME" "$VERSION_WIDTH" "$HEADER_VER"
+    printf '\n| %s | %s |' "$SEP_NAME" "$SEP_VER"
+    while IFS=$'\t' read -r display_name version_str; do
+        printf '\n| %-*s | %-*s |' "$NAME_WIDTH" "$display_name" "$VERSION_WIDTH" "$version_str"
+    done <<< "$ROWS"
+)
+
+# Replace the table in README.md between the markers
+awk -v table="$TABLE" '
+    /^\| Application/ { skip=1; print table; next }
+    skip && /^\|/ { next }
+    skip { skip=0 }
+    { print }
+' "$README" > "$README_TMP"
+
+mv "$README_TMP" "$README"
+echo "Updated versions table in README.md"


### PR DESCRIPTION
Update pinned nixpkgs-unstable and add `hack/update-readme-versions.sh`
to automatically regenerate the README versions table from the nix
devShell. The script runs as part of `make nix-update`.

Kubernetes 1.37 is pending in nixpkgs-unstable.